### PR TITLE
feat: port remaining landing components from turquoise-koala

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -23,6 +23,7 @@
   --warning-yellow: #f59e0b;
   --error-red: #ef4444;
   --accent-purple: #8b5cf6;
+  --purple: #8b5cf6;
 
   --font-size: 16px;
   --font-weight-medium: 500;

--- a/components/landing/ContentGeneration.tsx
+++ b/components/landing/ContentGeneration.tsx
@@ -1,0 +1,286 @@
+"use client";
+
+import { Badge } from "../ui/badge";
+import { Check, ArrowRight, ExternalLink } from "lucide-react";
+import { useState } from "react";
+import { Button } from "../ui/button";
+import { cn } from "@/lib/utils";
+
+// Editor Preview Component
+function EditorPreview() {
+  const [activeTab, setActiveTab] = useState<"A" | "B" | "C">("A");
+
+  const handleKeyDown = (event: React.KeyboardEvent, tab: "A" | "B" | "C") => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      setActiveTab(tab);
+    }
+  };
+
+  const drafts = {
+    A: {
+      subject: "Congrats on the Series B, Sarah—let's talk about scaling your data stack",
+      body: `Hi Sarah,
+
+Saw Acme just close a $45M Series B—congrats! With that kind of growth capital, I imagine you're thinking hard about how to scale your data infrastructure without the usual enterprise tax.
+
+We built abm.dev for teams like yours: high-quality account intelligence with confidence scores, deterministic enrichment, and transparent cost-plus pricing. No black-box vendors, no surprise bills.
+
+Would love to show you how we're helping companies like Stripe and Plaid turn a seed email into verified, cited, fresh data in under 200ms.
+
+Worth 15 minutes next week?
+
+Best,
+Alex`,
+      rationale: ["New Funding", "Tech Fit", "Persona Pain"],
+      sources: [
+        { name: "Crunchbase", url: "#" },
+        { name: "LinkedIn", url: "#" },
+        { name: "Company Blog", url: "#" }
+      ],
+      validated: true
+    },
+    B: {
+      subject: "Quick question about Acme's data enrichment strategy",
+      body: `Hi Sarah,
+
+I noticed Acme recently raised $45M in Series B funding. At that stage, data accuracy and pipeline reliability become critical—especially when you're scaling fast.
+
+abm.dev provides GTM intelligence with full audit trails, confidence scoring, and cost controls. We've helped similar-stage companies reduce enrichment costs by 40% while improving data quality.
+
+Happy to share a quick demo or sample response if you're interested.
+
+Thanks,
+Alex`,
+      rationale: ["New Funding", "Cost Conscious"],
+      sources: [
+        { name: "Crunchbase", url: "#" },
+        { name: "LinkedIn", url: "#" }
+      ],
+      validated: true
+    },
+    C: {
+      subject: "Scaling your GTM stack post-Series B",
+      body: `Sarah,
+
+$45M is a great milestone. Now comes the hard part: scaling without breaking your pipeline.
+
+We built abm.dev to solve exactly this—deterministic enrichment, transparent pricing, multi-model support. Teams at Stripe and Plaid use us to get verified account data with full citations and confidence scores.
+
+Let me know if you'd like to see how it works.
+
+Alex`,
+      rationale: ["New Funding", "Direct Approach"],
+      sources: [
+        { name: "Crunchbase", url: "#" }
+      ],
+      validated: false
+    }
+  };
+
+  const currentDraft = drafts[activeTab];
+
+  return (
+    <div className="bg-[var(--navy)]/50 border-2 border-[var(--electric-blue)]/30 rounded-lg backdrop-blur-sm overflow-hidden lg:mt-12">
+      {/* Tabs */}
+      <div className="border-b border-[var(--electric-blue)]/20 bg-[var(--navy)]/30">
+        <div className="flex" role="tablist" aria-label="Content generation drafts">
+          {(["A", "B", "C"] as const).map((tab) => (
+            <button
+              key={tab}
+              onClick={() => setActiveTab(tab)}
+              onKeyDown={(e) => handleKeyDown(e, tab)}
+              role="tab"
+              aria-selected={activeTab === tab}
+              aria-controls={`draft-panel-${tab}`}
+              tabIndex={activeTab === tab ? 0 : -1}
+              className={cn(
+                "px-6 py-3 text-sm transition-colors",
+                activeTab === tab
+                  ? "text-[var(--electric-blue)] border-b-2 border-[var(--electric-blue)] bg-[var(--electric-blue)]/10"
+                  : "text-[var(--cream)]/60 hover:text-[var(--cream)]"
+              )}
+              style={{ fontFamily: '"Courier New", Courier, monospace' }}
+            >
+              Draft {tab}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Content Area */}
+      <div className="grid grid-cols-1 lg:grid-cols-12 gap-0" role="tabpanel" id={`draft-panel-${activeTab}`} aria-labelledby={`tab-${activeTab}`}>
+        {/* Main Editor */}
+        <div className="lg:col-span-8 p-6 border-r border-[var(--electric-blue)]/10">
+          {/* Subject Line */}
+          <div className="mb-4">
+            <label className="text-[var(--cream)]/60 text-xs uppercase tracking-wide mb-2 block" style={{ fontFamily: '"Courier New", Courier, monospace' }}>
+              Subject
+            </label>
+            <div className="text-[var(--cream)] text-lg leading-relaxed">
+              {currentDraft.subject.split(/(\{[^}]+\})/g).map((part, idx) => {
+                if (part.startsWith("{") && part.endsWith("}")) {
+                  return (
+                    <span key={idx} className="bg-[var(--turquoise)]/20 text-[var(--turquoise)] px-1 rounded">
+                      {part}
+                    </span>
+                  );
+                }
+                return part;
+              })}
+            </div>
+          </div>
+
+          {/* Body */}
+          <div>
+            <label className="text-[var(--cream)]/60 text-xs uppercase tracking-wide mb-2 block" style={{ fontFamily: '"Courier New", Courier, monospace' }}>
+              Body
+            </label>
+            <div className="text-[var(--cream)]/90 whitespace-pre-line leading-relaxed">
+              {currentDraft.body.split(/(\$45M|Series B|Acme|Sarah|Stripe|Plaid|abm\.dev)/g).map((part, idx) => {
+                if (["$45M", "Series B", "Acme", "Sarah", "Stripe", "Plaid", "abm.dev"].includes(part)) {
+                  return (
+                    <span key={idx} className="bg-[var(--turquoise)]/20 text-[var(--turquoise)] px-0.5 rounded">
+                      {part}
+                    </span>
+                  );
+                }
+                return part;
+              })}
+            </div>
+          </div>
+        </div>
+
+        {/* Right Rail */}
+        <div className="lg:col-span-4 p-6 space-y-6 bg-[var(--navy)]/30">
+          {/* Rationale */}
+          <div>
+            <h4 className="text-[var(--cream)] text-sm uppercase tracking-wide mb-3" style={{ fontFamily: '"Courier New", Courier, monospace' }}>
+              Rationale
+            </h4>
+            <div className="flex flex-wrap gap-2">
+              {currentDraft.rationale.map((item, idx) => (
+                <Badge
+                  key={idx}
+                  className="bg-[var(--purple)]/20 text-[var(--purple)] border border-[var(--purple)]/30"
+                  style={{
+                    animationDelay: `${idx * 60}ms`,
+                    animation: "fadeIn 0.3s ease-in forwards"
+                  }}
+                >
+                  {item}
+                </Badge>
+              ))}
+            </div>
+          </div>
+
+          {/* Sources */}
+          <div>
+            <h4 className="text-[var(--cream)] text-sm uppercase tracking-wide mb-3" style={{ fontFamily: '"Courier New", Courier, monospace' }}>
+              Sources
+            </h4>
+            <div className="space-y-2">
+              {currentDraft.sources.map((source, idx) => (
+                <a
+                  key={idx}
+                  href={source.url}
+                  className="flex items-center gap-2 text-[var(--electric-blue)] hover:text-[var(--turquoise)] transition-colors text-sm"
+                >
+                  <ExternalLink className="w-3 h-3" />
+                  <span>{source.name}</span>
+                </a>
+              ))}
+            </div>
+          </div>
+
+          {/* Validate Badge */}
+          <div>
+            <h4 className="text-[var(--cream)] text-sm uppercase tracking-wide mb-3" style={{ fontFamily: '"Courier New", Courier, monospace' }}>
+              Validation
+            </h4>
+            <Badge
+              variant={currentDraft.validated ? "success" : "warning"}
+            >
+              {currentDraft.validated ? "Passed" : "Needs Review"}
+            </Badge>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// Main Section Component
+export function ContentGeneration() {
+  return (
+    <section className="relative bg-[var(--navy)] py-16 lg:py-24 overflow-hidden">
+      {/* Film grain texture */}
+      <div
+        className="absolute inset-0 opacity-[0.07] pointer-events-none"
+        style={{
+          backgroundImage: `url("data:image/svg+xml,%3Csvg viewBox='0 0 400 400' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' /%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noiseFilter)' /%3E%3C/svg%3E")`,
+        }}
+      />
+
+      <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="grid grid-cols-1 lg:grid-cols-12 gap-10 lg:gap-16 items-start">
+          {/* Left Column - Content & Process Rail */}
+          <div className="lg:col-span-4 space-y-6">
+            {/* Eyebrow */}
+            <Badge variant="secondary" className="bg-[var(--electric-blue)]/20 text-[var(--electric-blue)] border border-[var(--electric-blue)]/30">
+              From configuration to send-ready drafts
+            </Badge>
+
+            {/* H2 */}
+            <h2 className="text-white text-4xl lg:text-5xl" style={{ fontFamily: 'Georgia, "Times New Roman", serif' }}>
+              Content generation that adapts to your pipeline
+            </h2>
+
+            {/* Lead paragraph */}
+            <p className="text-[var(--cream)] text-lg" style={{ fontFamily: 'Georgia, "Times New Roman", serif' }}>
+              Provide a CRM reference, a prompt, and instructions from any source. The system resolves context, calls multiple models, and returns ranked drafts with rationale, citations, and validation—ready to review and ship.
+            </p>
+
+            {/* Bullet list */}
+            <ul className="space-y-4">
+              {[
+                "Multi-model draft set: precision vs. speed options",
+                "Rationale, source citations, and freshness tags",
+                "Tone, length, and compliance constraints enforced",
+                "Idempotent requests with request_id and audit logs"
+              ].map((item, idx) => (
+                <li key={idx} className="flex items-start gap-3">
+                  <div className="mt-1 flex-shrink-0 w-5 h-5 rounded-full bg-[var(--electric-blue)]/20 flex items-center justify-center">
+                    <Check className="w-3 h-3 text-[var(--electric-blue)]" />
+                  </div>
+                  <span className="text-[var(--cream)]">{item}</span>
+                </li>
+              ))}
+            </ul>
+
+            {/* Supporting paragraph */}
+            <p className="text-[var(--cream)]/70 text-sm">
+              The pipeline validates inputs, collects references, assembles prompts, generates drafts across providers, and quality-checks each output for tone, required elements, and personalization before returning results.
+            </p>
+
+            {/* CTA Row */}
+            <div className="flex flex-col sm:flex-row gap-3 pt-4">
+              <Button size="lg" className="bg-[var(--turquoise)] hover:bg-[var(--dark-turquoise)] text-[var(--navy)]">
+                Generate a draft
+                <ArrowRight className="w-4 h-4 ml-2" />
+              </Button>
+              <Button size="lg" variant="outline" className="border-[var(--electric-blue)] text-[var(--electric-blue)] hover:bg-[var(--electric-blue)]/10">
+                See prompt package
+              </Button>
+            </div>
+          </div>
+
+          {/* Right Column - Editorial Preview */}
+          <div className="lg:col-span-8">
+            <EditorPreview />
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/components/landing/CtaBand.tsx
+++ b/components/landing/CtaBand.tsx
@@ -1,0 +1,70 @@
+import { Button } from "../ui/button";
+import { ArrowRight, BookOpen, Calendar } from "lucide-react";
+
+export function CtaBand() {
+  return (
+    <section className="relative py-20 lg:py-28 bg-[var(--navy)] overflow-hidden">
+      {/* Decorative blur circles */}
+      <div className="absolute inset-0 opacity-10">
+        <div className="absolute top-0 left-1/4 w-96 h-96 bg-[var(--turquoise)] rounded-full blur-3xl"></div>
+        <div className="absolute bottom-0 right-1/4 w-96 h-96 bg-[var(--turquoise)] rounded-full blur-3xl opacity-80"></div>
+      </div>
+
+      {/* Content */}
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center relative z-10">
+        <h2 className="text-4xl lg:text-5xl font-bold text-[var(--cream)] mb-4">
+          Time to first call: 3 minutes
+        </h2>
+        <p className="text-lg text-[var(--cream)]/80 mb-8 max-w-2xl mx-auto">
+          Get your API key, make your first enrichment call, and start building production-ready workflows today.
+        </p>
+
+        {/* CTAs */}
+        <div className="flex flex-col sm:flex-row gap-4 justify-center items-center">
+          {/* Primary CTA - Start Building */}
+          <Button
+            size="lg"
+            className="bg-[var(--turquoise)] hover:bg-[var(--turquoise)]/90 text-[var(--navy)] font-semibold"
+            asChild
+          >
+            <a href="/api-keys">
+              Start Building
+              <ArrowRight className="w-4 h-4 ml-2" />
+            </a>
+          </Button>
+
+          {/* Secondary CTA - View Docs */}
+          <Button
+            size="lg"
+            variant="outline"
+            className="border-[var(--cream)]/30 bg-transparent text-[var(--cream)] hover:bg-[var(--cream)]/10 hover:text-[var(--cream)] hover:border-[var(--cream)]/50"
+            asChild
+          >
+            <a href="/api-reference">
+              View Docs
+              <BookOpen className="w-4 h-4 ml-2" />
+            </a>
+          </Button>
+
+          {/* Tertiary CTA - Book a Pilot */}
+          <Button
+            size="lg"
+            variant="outline"
+            className="border-[var(--cream)]/30 bg-transparent text-[var(--cream)] hover:bg-[var(--cream)]/10 hover:text-[var(--cream)] hover:border-[var(--cream)]/50"
+            asChild
+          >
+            <a href="mailto:support@abm.dev?subject=Book a Pilot Program">
+              Book a Pilot
+              <Calendar className="w-4 h-4 ml-2" />
+            </a>
+          </Button>
+        </div>
+
+        {/* No credit card text */}
+        <div className="mt-8 text-sm text-[var(--cream)]/60">
+          No credit card required
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/components/landing/EnrichmentAgents.tsx
+++ b/components/landing/EnrichmentAgents.tsx
@@ -1,0 +1,45 @@
+export function EnrichmentAgents() {
+  return (
+    <section className="relative py-24 lg:py-32 overflow-hidden">
+      {/* Background Image */}
+      <div
+        className="absolute inset-0 bg-cover bg-center"
+        style={{
+          backgroundImage: `url(/images/testimonial-bg.jpg)`,
+        }}
+      />
+
+      {/* Dark overlay */}
+      <div className="absolute inset-0 bg-[#0A1F3D]/70" />
+
+      {/* Film grain texture */}
+      <div
+        className="absolute inset-0 opacity-[0.15] pointer-events-none"
+        style={{
+          backgroundImage: `url("data:image/svg+xml,%3Csvg viewBox='0 0 400 400' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' /%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noiseFilter)' /%3E%3C/svg%3E")`,
+        }}
+      />
+
+      <div className="relative max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="text-center space-y-8">
+          {/* Quote */}
+          <blockquote className="space-y-6">
+            <p
+              className="text-[#FAEBD7] text-2xl lg:text-3xl leading-relaxed"
+              style={{ fontFamily: 'Georgia, "Times New Roman", serif' }}
+            >
+              &quot;abm.dev&apos;s confidence scores and audit trails ended the &apos;is this data real?&apos; debates. We retired three legacy vendors and consolidated our GTM pipeline without compromising quality.&quot;
+            </p>
+
+            <footer className="pt-4">
+              <div className="text-[#FAEBD7]">
+                <div className="text-lg">Oscar Avatare</div>
+                <div className="text-[#FAEBD7]/70">CTO, Saphira AI</div>
+              </div>
+            </footer>
+          </blockquote>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/components/landing/EnrichmentFeature.tsx
+++ b/components/landing/EnrichmentFeature.tsx
@@ -1,0 +1,331 @@
+"use client";
+
+import { Button } from "../ui/button";
+import { Badge } from "../ui/badge";
+import { Check, ArrowRight, Code, Database, Clock } from "lucide-react";
+import { useState } from "react";
+import { cn } from "@/lib/utils";
+
+export function EnrichmentFeature() {
+  const [activeTab, setActiveTab] = useState<"fields" | "json" | "audit">("fields");
+
+  const handleKeyDown = (event: React.KeyboardEvent, tab: "fields" | "json" | "audit") => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      setActiveTab(tab);
+    }
+  };
+
+  return (
+    <section className="relative bg-[#F5F5DC] py-16 lg:py-24 overflow-hidden">
+      {/* Film grain texture */}
+      <div
+        className="absolute inset-0 opacity-[0.07] pointer-events-none"
+        style={{
+          backgroundImage: `url("data:image/svg+xml,%3Csvg viewBox='0 0 400 400' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' /%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noiseFilter)' /%3E%3C/svg%3E")`,
+        }}
+      />
+
+      <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="grid grid-cols-1 lg:grid-cols-12 gap-10 lg:gap-16 items-center">
+          {/* Left Column - Product Card */}
+          <div className="lg:col-span-7">
+            <div className="bg-[#0A1F3D] border border-[#40E0D0]/20 rounded-lg shadow-2xl overflow-hidden">
+              {/* Tabs */}
+              <div className="border-b border-[#40E0D0]/20 bg-[#0A1F3D]/50 backdrop-blur-sm">
+                <div className="flex" role="tablist" aria-label="Enrichment data views">
+                  {(["fields", "json", "audit"] as const).map((tab) => (
+                    <button
+                      key={tab}
+                      onClick={() => setActiveTab(tab)}
+                      onKeyDown={(e) => handleKeyDown(e, tab)}
+                      role="tab"
+                      aria-selected={activeTab === tab}
+                      aria-controls={`enrichment-panel-${tab}`}
+                      tabIndex={activeTab === tab ? 0 : -1}
+                      className={cn(
+                        "px-6 py-3 text-sm capitalize transition-colors",
+                        activeTab === tab
+                          ? "text-[#40E0D0] border-b-2 border-[#40E0D0]"
+                          : "text-[#FAEBD7]/60 hover:text-[#FAEBD7]"
+                      )}
+                    >
+                      {tab}
+                    </button>
+                  ))}
+                </div>
+              </div>
+
+              {/* Tab Content */}
+              <div className="p-6" role="tabpanel" id={`enrichment-panel-${activeTab}`} aria-labelledby={`tab-${activeTab}`}>
+                {activeTab === "fields" && (
+                  <div className="space-y-4">
+                    {/* Profile header */}
+                    <div className="flex items-start gap-4">
+                      <div className="w-16 h-16 rounded-full bg-gradient-to-br from-[#40E0D0] to-[#20B2AA] flex items-center justify-center text-[#0A1F3D] text-xl font-semibold">
+                        JS
+                      </div>
+                      <div className="flex-1">
+                        <div className="flex items-center gap-2 mb-1">
+                          <h3 className="text-[#FAEBD7] text-lg font-semibold">Jane Smith</h3>
+                          <Badge className="bg-[#10B981] text-white text-xs border-0">
+                            High
+                          </Badge>
+                        </div>
+                        <p className="text-[#FAEBD7]/60 text-sm">VP of Engineering</p>
+                        <p className="text-[#FAEBD7]/60 text-sm">Acme Corp</p>
+                      </div>
+                    </div>
+
+                    {/* Fields */}
+                    <div className="space-y-3 pt-2">
+                      <DataField
+                        label="Email"
+                        value="jane.smith@acme.com"
+                        confidence="High"
+                        source="LinkedIn, Clearbit"
+                        freshness="Updated 2d ago"
+                      />
+                      <DataField
+                        label="Title"
+                        value="VP of Engineering"
+                        confidence="High"
+                        source="LinkedIn"
+                        freshness="Updated 1w ago"
+                      />
+                      <DataField
+                        label="Company"
+                        value="Acme Corp"
+                        confidence="High"
+                        source="Clearbit, ZoomInfo"
+                        freshness="Updated 3d ago"
+                      />
+                      <DataField
+                        label="Phone"
+                        value="+1 (555) 123-4567"
+                        confidence="Medium"
+                        source="Public records"
+                        freshness="Updated 2w ago"
+                      />
+                    </div>
+                  </div>
+                )}
+
+                {activeTab === "json" && (
+                  <div className="bg-[#0A1F3D]/80 rounded p-4 overflow-x-auto">
+                    <pre className="text-xs text-[#FAEBD7]" style={{ fontFamily: '"Courier New", Courier, monospace' }}>
+                      <code>{`{
+  "person": {
+    "name": "Jane Smith",
+    "email": "jane.smith@acme.com",
+    "title": "VP of Engineering",
+    "confidence": 0.98,
+    "sources": ["linkedin", "clearbit"],
+    "updated_at": "2025-11-12T14:32:00Z"
+  },
+  "company": {
+    "name": "Acme Corp",
+    "domain": "acme.com",
+    "employees": "500-1000",
+    "confidence": 0.95
+  }
+}`}</code>
+                    </pre>
+                  </div>
+                )}
+
+                {activeTab === "audit" && (
+                  <div className="space-y-3">
+                    <AuditEntry
+                      timestamp="2025-11-12 14:32"
+                      action="Email verified"
+                      source="LinkedIn API"
+                      confidence="98%"
+                    />
+                    <AuditEntry
+                      timestamp="2025-11-12 14:32"
+                      action="Title confirmed"
+                      source="LinkedIn Profile"
+                      confidence="98%"
+                    />
+                    <AuditEntry
+                      timestamp="2025-11-10 09:15"
+                      action="Company data merged"
+                      source="Clearbit + ZoomInfo"
+                      confidence="95%"
+                    />
+                    <AuditEntry
+                      timestamp="2025-11-05 16:22"
+                      action="Phone number found"
+                      source="Public records"
+                      confidence="72%"
+                    />
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+
+          {/* Right Column - Content */}
+          <div className="lg:col-span-5 space-y-6">
+            {/* Eyebrow */}
+            <Badge variant="secondary" className="bg-[#0A1F3D]/90 text-[#40E0D0] border border-[#40E0D0]/50">
+              Enrichment that won&apos;t break your pipeline
+            </Badge>
+
+            {/* H1 */}
+            <h2 className="text-[#0A1F3D] text-4xl lg:text-5xl font-serif leading-tight">
+              Simply the deepest, most accurate enrichment API
+            </h2>
+
+            {/* Lead paragraph */}
+            <p className="text-[#0A1F3D]/80 text-lg font-serif leading-relaxed">
+              Turn a seed like an email or domain into verified person and company intelligence with confidence scores, sources, and freshness—all in one consistent schema.
+            </p>
+
+            {/* Bullet list */}
+            <ul className="space-y-4">
+              {[
+                "Deterministic over guesses with full audit trails",
+                "Confidence-scored fields and freshness windows",
+                "Cache, batch, and off-peak controls to cut costs"
+              ].map((item, idx) => (
+                <li key={idx} className="flex items-start gap-3">
+                  <div className="mt-1 flex-shrink-0 w-5 h-5 rounded-full bg-[#40E0D0]/20 flex items-center justify-center">
+                    <Check className="w-3 h-3 text-[#40E0D0]" />
+                  </div>
+                  <span className="text-[#0A1F3D]/80 leading-relaxed">{item}</span>
+                </li>
+              ))}
+            </ul>
+
+            {/* Supporting paragraph */}
+            <p className="text-[#0A1F3D]/70 text-sm leading-relaxed">
+              The engine merges multiple sources, normalizes to a canonical schema, and emits transparent citations so every field is explainable. Teams decide confidence thresholds and sources of record.
+            </p>
+
+            {/* CTA Row */}
+            <div className="flex flex-col sm:flex-row gap-3 pt-4">
+              <Button
+                size="lg"
+                className="bg-[#40E0D0] hover:bg-[#20B2AA] text-[#0A1F3D]"
+                asChild
+              >
+                <a href="/api-keys">
+                  Get API key
+                  <ArrowRight className="w-4 h-4 ml-2" />
+                </a>
+              </Button>
+              <Button
+                size="lg"
+                variant="outline"
+                className="border-[#0A1F3D]/30 text-[#0A1F3D] hover:bg-[#0A1F3D]/10"
+                asChild
+              >
+                <a href="/api-reference">
+                  See schema
+                  <Code className="w-4 h-4 ml-2" />
+                </a>
+              </Button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// Helper component for data fields
+function DataField({
+  label,
+  value,
+  confidence,
+  source,
+  freshness
+}: {
+  label: string;
+  value: string;
+  confidence: "High" | "Medium" | "Low";
+  source: string;
+  freshness: string;
+}) {
+  const confidenceColors = {
+    High: { bg: "#10B98120", text: "#10B981" },
+    Medium: { bg: "#F59E0B20", text: "#F59E0B" },
+    Low: { bg: "#EF444420", text: "#EF4444" }
+  };
+
+  const colors = confidenceColors[confidence];
+
+  return (
+    <div className="border border-[#40E0D0]/10 rounded p-3 bg-[#0A1F3D]/30">
+      <div className="flex items-center justify-between mb-2">
+        <span className="text-[#FAEBD7]/60 text-xs uppercase tracking-wide font-medium">{label}</span>
+        <Badge
+          style={{
+            backgroundColor: colors.bg,
+            color: colors.text,
+            border: 0
+          }}
+          className="text-xs"
+        >
+          {confidence}
+        </Badge>
+      </div>
+      <p className="text-[#FAEBD7] mb-2 font-medium">{value}</p>
+      <div className="flex items-center gap-2 text-xs text-[#FAEBD7]/50">
+        <Database className="w-3 h-3" />
+        <span className="px-2 py-1 bg-[#40E0D0]/10 rounded text-[#40E0D0]">{source}</span>
+        <span>•</span>
+        <Clock className="w-3 h-3" />
+        <span>{freshness}</span>
+      </div>
+    </div>
+  );
+}
+
+// Helper component for audit entries
+function AuditEntry({
+  timestamp,
+  action,
+  source,
+  confidence
+}: {
+  timestamp: string;
+  action: string;
+  source: string;
+  confidence: string;
+}) {
+  const confidenceValue = parseInt(confidence);
+  const confidenceColor = confidenceValue >= 90
+    ? { bg: "#10B98120", text: "#10B981" }
+    : confidenceValue >= 75
+    ? { bg: "#F59E0B20", text: "#F59E0B" }
+    : { bg: "#EF444420", text: "#EF4444" };
+
+  return (
+    <div className="border-l-2 border-[#40E0D0]/30 pl-4 py-2">
+      <div className="flex items-center justify-between mb-1">
+        <p className="text-[#FAEBD7] text-sm font-medium">{action}</p>
+        <Badge
+          style={{
+            backgroundColor: confidenceColor.bg,
+            color: confidenceColor.text,
+            border: 0
+          }}
+          className="text-xs"
+        >
+          {confidence}
+        </Badge>
+      </div>
+      <div className="flex items-center gap-2 text-[#FAEBD7]/60 text-xs">
+        <Database className="w-3 h-3" />
+        <p>{source}</p>
+      </div>
+      <div className="flex items-center gap-2 text-[#FAEBD7]/40 text-xs mt-1">
+        <Clock className="w-3 h-3" />
+        <p>{timestamp}</p>
+      </div>
+    </div>
+  );
+}

--- a/components/landing/PricingTeaser.tsx
+++ b/components/landing/PricingTeaser.tsx
@@ -1,0 +1,223 @@
+import { Button } from "../ui/button";
+import { Badge } from "../ui/badge";
+import { Check, DollarSign } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export function PricingTeaser() {
+  return (
+    <section className="py-20 lg:py-28 bg-[var(--cream)] relative overflow-hidden">
+      {/* Film grain overlay */}
+      <div
+        className="absolute inset-0 opacity-[0.03] pointer-events-none"
+        style={{
+          backgroundImage: `url("data:image/svg+xml,%3Csvg viewBox='0 0 400 400' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noiseFilter)'/%3E%3C/svg%3E")`,
+          backgroundRepeat: 'repeat',
+          backgroundSize: '128px 128px'
+        }}
+      />
+
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 relative">
+        <div className="text-center mb-16">
+          <Badge
+            variant="outline"
+            className="mb-6 bg-[var(--navy)]/10 border-[var(--navy)]/20 text-[var(--navy)]"
+          >
+            Transparent pricing
+          </Badge>
+
+          <h2 className="text-[var(--navy)] mb-4 text-4xl lg:text-5xl font-serif">
+            Transparent, cost-plus pricing
+          </h2>
+          <p className="text-lg text-[var(--navy)]/70 max-w-2xl mx-auto">
+            No markup surprises. You see our costs, our margin floor, and exactly what you pay per enrichment.
+          </p>
+        </div>
+
+        <div className="grid md:grid-cols-3 gap-8 max-w-5xl mx-auto mb-12">
+          {/* Free Tier */}
+          <div className="bg-white border-2 border-[var(--navy)]/20 rounded-lg p-8 shadow-lg relative">
+
+            <div className="mb-6">
+              <h3 className="text-[var(--navy)] mb-3 text-2xl font-serif">
+                Free
+              </h3>
+              <div className="flex items-baseline gap-1 mb-2">
+                <span className="text-[var(--navy)] text-4xl font-serif">
+                  $0
+                </span>
+              </div>
+              <p className="text-sm text-[var(--navy)]/70">
+                5 enrichments + 5 drafts/month
+              </p>
+            </div>
+
+            <ul className="space-y-3 mb-8">
+              <li className="flex items-start gap-2 text-sm">
+                <Check className="w-4 h-4 text-[var(--turquoise)] flex-shrink-0 mt-0.5" />
+                <span className="text-[var(--navy)]">Test API keys (sk_test)</span>
+              </li>
+              <li className="flex items-start gap-2 text-sm">
+                <Check className="w-4 h-4 text-[var(--turquoise)] flex-shrink-0 mt-0.5" />
+                <span className="text-[var(--navy)]">Full API access</span>
+              </li>
+              <li className="flex items-start gap-2 text-sm">
+                <Check className="w-4 h-4 text-[var(--turquoise)] flex-shrink-0 mt-0.5" />
+                <span className="text-[var(--navy)]">OpenAPI docs</span>
+              </li>
+              <li className="flex items-start gap-2 text-sm">
+                <Check className="w-4 h-4 text-[var(--turquoise)] flex-shrink-0 mt-0.5" />
+                <span className="text-[var(--navy)]">Community support</span>
+              </li>
+            </ul>
+
+            <Button
+              variant="outline"
+              className="w-full border-2 border-[var(--navy)] text-[var(--navy)] hover:bg-[var(--navy)] hover:text-white"
+              asChild
+            >
+              <a href="/api-keys">Start Free</a>
+            </Button>
+          </div>
+
+          {/* Pay-as-you-go - Featured/Most Popular */}
+          <div className="bg-[var(--navy)] border-2 border-[var(--electric-blue)] rounded-lg p-8 shadow-xl relative transform scale-105">
+
+            <div className="absolute -top-3 left-1/2 transform -translate-x-1/2">
+              <Badge className="bg-[var(--electric-blue)] text-white border-0 font-mono uppercase text-xs px-4 py-1">
+                MOST POPULAR
+              </Badge>
+            </div>
+
+            <div className="mb-6">
+              <h3 className="text-white mb-3 text-2xl font-serif">
+                Pay-as-you-go
+              </h3>
+              <div className="space-y-2">
+                <div className="flex items-baseline gap-1">
+                  <span className="text-[var(--turquoise)] text-3xl font-serif">
+                    $0.15
+                  </span>
+                  <span className="text-sm text-white/70 font-mono">
+                    /enrichment
+                  </span>
+                </div>
+                <div className="flex items-baseline gap-1">
+                  <span className="text-[var(--turquoise)] text-3xl font-serif">
+                    $0.07
+                  </span>
+                  <span className="text-sm text-white/70 font-mono">
+                    /draft
+                  </span>
+                </div>
+              </div>
+              <p className="text-sm text-white/80 mt-2">
+                Volume discounts at scale
+              </p>
+            </div>
+
+            <ul className="space-y-3 mb-8">
+              <li className="flex items-start gap-2 text-sm">
+                <Check className="w-4 h-4 text-[var(--turquoise)] flex-shrink-0 mt-0.5" />
+                <span className="text-white">Production keys (sk_live)</span>
+              </li>
+              <li className="flex items-start gap-2 text-sm">
+                <Check className="w-4 h-4 text-[var(--turquoise)] flex-shrink-0 mt-0.5" />
+                <span className="text-white">Confidence scores & audit trails</span>
+              </li>
+              <li className="flex items-start gap-2 text-sm">
+                <Check className="w-4 h-4 text-[var(--turquoise)] flex-shrink-0 mt-0.5" />
+                <span className="text-white">Email support</span>
+              </li>
+              <li className="flex items-start gap-2 text-sm">
+                <Check className="w-4 h-4 text-[var(--turquoise)] flex-shrink-0 mt-0.5" />
+                <span className="text-white">99.9% SLA</span>
+              </li>
+            </ul>
+
+            <Button
+              className="w-full bg-[var(--electric-blue)] hover:bg-[var(--electric-blue)]/90 text-white border-0"
+              asChild
+            >
+              <a href="/api-keys">Start Building</a>
+            </Button>
+          </div>
+
+          {/* Enterprise */}
+          <div className="bg-white border-2 border-[var(--navy)]/20 rounded-lg p-8 shadow-lg relative">
+
+            <div className="mb-6">
+              <h3 className="text-[var(--navy)] mb-3 text-2xl font-serif">
+                Enterprise
+              </h3>
+              <div className="flex items-baseline gap-1 mb-2">
+                <span className="text-[var(--navy)] text-4xl font-serif">
+                  Custom
+                </span>
+              </div>
+              <p className="text-sm text-[var(--navy)]/70">
+                Volume commitments & custom SLA
+              </p>
+            </div>
+
+            <ul className="space-y-3 mb-8">
+              <li className="flex items-start gap-2 text-sm">
+                <Check className="w-4 h-4 text-[var(--turquoise)] flex-shrink-0 mt-0.5" />
+                <span className="text-[var(--navy)]">Dedicated support</span>
+              </li>
+              <li className="flex items-start gap-2 text-sm">
+                <Check className="w-4 h-4 text-[var(--turquoise)] flex-shrink-0 mt-0.5" />
+                <span className="text-[var(--navy)]">Custom data sources</span>
+              </li>
+              <li className="flex items-start gap-2 text-sm">
+                <Check className="w-4 h-4 text-[var(--turquoise)] flex-shrink-0 mt-0.5" />
+                <span className="text-[var(--navy)]">Private deployment options</span>
+              </li>
+              <li className="flex items-start gap-2 text-sm">
+                <Check className="w-4 h-4 text-[var(--turquoise)] flex-shrink-0 mt-0.5" />
+                <span className="text-[var(--navy)]">Custom SLA & success team</span>
+              </li>
+            </ul>
+
+            <Button
+              variant="outline"
+              className="w-full border-2 border-[var(--navy)] text-[var(--navy)] hover:bg-[var(--navy)] hover:text-white"
+              asChild
+            >
+              <a href="mailto:sales@abm.dev">Book a Pilot</a>
+            </Button>
+          </div>
+        </div>
+
+        {/* How cost-plus works - Explanation Card */}
+        <div className="max-w-3xl mx-auto bg-white border-2 border-[var(--navy)]/30 rounded-lg p-8 shadow-lg relative">
+
+          <div className="flex items-start gap-6">
+            <div className="w-14 h-14 rounded-full bg-[var(--electric-blue)]/10 flex items-center justify-center flex-shrink-0 border-2 border-[var(--electric-blue)]/30">
+              <DollarSign className="w-6 h-6 text-[var(--electric-blue)]" />
+            </div>
+            <div className="flex-1">
+              <h4 className="text-[var(--navy)] mb-3 text-xl font-serif">
+                How cost-plus works
+              </h4>
+              <p className="text-sm text-[var(--navy)]/70 mb-4 leading-relaxed">
+                You see the upstream provider costs, our margin (minimum 15%), and your final price.
+                As provider costs drop or you scale, your unit economics improve automatically.
+              </p>
+              <div
+                className={cn(
+                  "inline-flex items-center gap-3 text-xs bg-[var(--navy)] px-4 py-3 rounded border-2 border-[var(--turquoise)] font-mono"
+                )}
+              >
+                <span className="text-white">Provider: $0.08</span>
+                <span className="text-[var(--turquoise)]">+</span>
+                <span className="text-white">Margin: $0.05</span>
+                <span className="text-[var(--turquoise)]">=</span>
+                <span className="text-[var(--turquoise)]">Your price: $0.13</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/components/landing/QuickStart.tsx
+++ b/components/landing/QuickStart.tsx
@@ -1,0 +1,263 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "../ui/button";
+import { Badge } from "../ui/badge";
+import { Copy, Check, ArrowRight, Key, Sparkles } from "lucide-react";
+
+type Language = "curl" | "javascript" | "python";
+
+const codeExamples: Record<Language, string> = {
+  curl: `curl -X POST https://api.abm.dev/v1/enrich \\
+  -H "Authorization: Bearer YOUR_API_KEY" \\
+  -H "Content-Type: application/json" \\
+  -d '{
+    "email": "jane.smith@acme.com"
+  }'`,
+  javascript: `const response = await fetch('https://api.abm.dev/v1/enrich', {
+  method: 'POST',
+  headers: {
+    'Authorization': 'Bearer YOUR_API_KEY',
+    'Content-Type': 'application/json',
+  },
+  body: JSON.stringify({
+    email: 'jane.smith@acme.com'
+  }),
+});
+
+const data = await response.json();
+console.log(data);`,
+  python: `import requests
+
+response = requests.post(
+    'https://api.abm.dev/v1/enrich',
+    headers={
+        'Authorization': 'Bearer YOUR_API_KEY',
+        'Content-Type': 'application/json',
+    },
+    json={
+        'email': 'jane.smith@acme.com'
+    }
+)
+
+data = response.json()
+print(data)`,
+};
+
+const languageLabels: Record<Language, string> = {
+  curl: "cURL",
+  javascript: "JavaScript",
+  python: "Python",
+};
+
+export function QuickStart() {
+  const [selectedLang, setSelectedLang] = useState<Language>("curl");
+  const [copied, setCopied] = useState(false);
+  const [copiedClaude, setCopiedClaude] = useState(false);
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(codeExamples[selectedLang]);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent, lang: Language) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      setSelectedLang(lang);
+    }
+  };
+
+  const handleCopyToClaude = async () => {
+    const claudePrompt = `I'm integrating the ABM.dev API for data enrichment.
+
+Here's my current code:
+\`\`\`${selectedLang}
+${codeExamples[selectedLang]}
+\`\`\`
+
+API Documentation: https://abm.dev/api
+
+Help me:
+1. Understand what this code does
+2. Handle errors properly
+3. Implement best practices for rate limiting and retries`;
+
+    await navigator.clipboard.writeText(claudePrompt);
+    setCopiedClaude(true);
+    setTimeout(() => setCopiedClaude(false), 2000);
+  };
+
+  return (
+    <section className="relative bg-[#F5F5DC] py-16 lg:py-24 overflow-hidden">
+      {/* Subtle noise texture overlay */}
+      <div
+        className="absolute inset-0 opacity-[0.05] pointer-events-none"
+        style={{
+          backgroundImage: `url("data:image/svg+xml,%3Csvg viewBox='0 0 400 400' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' /%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noiseFilter)' /%3E%3C/svg%3E")`,
+        }}
+      />
+
+      <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="text-center mb-12">
+          <Badge
+            variant="secondary"
+            className="bg-[#40E0D0]/20 text-[#0A1F3D] border border-[#40E0D0]/50 mb-4"
+          >
+            <Sparkles className="w-3 h-3 mr-1" />
+            Start in 3 minutes
+          </Badge>
+          <h2
+            className="text-[#0A1F3D] text-4xl lg:text-5xl font-serif leading-tight mb-4"
+          >
+            Get started with one API call
+          </h2>
+          <p className="text-[#0A1F3D]/70 text-lg max-w-2xl mx-auto">
+            Sign up, grab your API key, and enrich your first contact in under 3 minutes.
+          </p>
+        </div>
+
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 items-start">
+          {/* Left: Steps */}
+          <div className="space-y-6">
+            <div className="flex items-start gap-4">
+              <div className="flex-shrink-0 w-10 h-10 rounded-full bg-[#40E0D0] flex items-center justify-center text-[#0A1F3D] font-bold">
+                1
+              </div>
+              <div>
+                <h3 className="text-[#0A1F3D] text-lg font-semibold mb-2">Get your API key</h3>
+                <p className="text-[#0A1F3D]/70 mb-3">
+                  Create a free account and generate your API key instantly.
+                </p>
+                <Button
+                  className="bg-[#40E0D0] hover:bg-[#20B2AA] text-[#0A1F3D]"
+                  asChild
+                >
+                  <a href="/api-keys">
+                    <Key className="w-4 h-4 mr-2" />
+                    Get API Key
+                  </a>
+                </Button>
+              </div>
+            </div>
+
+            <div className="flex items-start gap-4">
+              <div className="flex-shrink-0 w-10 h-10 rounded-full bg-[#40E0D0]/30 flex items-center justify-center text-[#0A1F3D] font-bold border-2 border-[#40E0D0]">
+                2
+              </div>
+              <div>
+                <h3 className="text-[#0A1F3D] text-lg font-semibold mb-2">Make your first request</h3>
+                <p className="text-[#0A1F3D]/70">
+                  Use the code example on the right. Replace <code className="bg-[#0A1F3D]/10 px-1 rounded text-sm">YOUR_API_KEY</code> with your actual key.
+                </p>
+              </div>
+            </div>
+
+            <div className="flex items-start gap-4">
+              <div className="flex-shrink-0 w-10 h-10 rounded-full bg-[#40E0D0]/30 flex items-center justify-center text-[#0A1F3D] font-bold border-2 border-[#40E0D0]">
+                3
+              </div>
+              <div>
+                <h3 className="text-[#0A1F3D] text-lg font-semibold mb-2">Explore the response</h3>
+                <p className="text-[#0A1F3D]/70 mb-3">
+                  Get enriched data with confidence scores, sources, and freshness indicators.
+                </p>
+                <Button
+                  variant="outline"
+                  className="border-[#0A1F3D]/30 text-[#0A1F3D] hover:bg-[#0A1F3D]/10"
+                  asChild
+                >
+                  <a href="/api-reference">
+                    View Full API Reference
+                    <ArrowRight className="w-4 h-4 ml-2" />
+                  </a>
+                </Button>
+              </div>
+            </div>
+          </div>
+
+          {/* Right: Code Example */}
+          <div className="bg-[#0A1F3D] rounded-lg shadow-2xl overflow-hidden">
+            {/* Language Tabs */}
+            <div className="border-b border-[#40E0D0]/20 bg-[#0A1F3D]/50">
+              <div className="flex" role="tablist" aria-label="Code example languages">
+                {(Object.keys(codeExamples) as Language[]).map((lang) => (
+                  <button
+                    key={lang}
+                    onClick={() => setSelectedLang(lang)}
+                    onKeyDown={(e) => handleKeyDown(e, lang)}
+                    role="tab"
+                    aria-selected={selectedLang === lang}
+                    aria-controls={`code-panel-${lang}`}
+                    tabIndex={selectedLang === lang ? 0 : -1}
+                    className={`px-4 py-3 text-sm transition-colors ${
+                      selectedLang === lang
+                        ? "text-[#40E0D0] border-b-2 border-[#40E0D0]"
+                        : "text-[#FAEBD7]/60 hover:text-[#FAEBD7]"
+                    }`}
+                  >
+                    {languageLabels[lang]}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {/* Code Block */}
+            <div className="p-4 relative" role="tabpanel" id={`code-panel-${selectedLang}`} aria-labelledby={`tab-${selectedLang}`}>
+              <pre className="text-[#FAEBD7] text-sm overflow-x-auto">
+                <code>{codeExamples[selectedLang]}</code>
+              </pre>
+            </div>
+
+            {/* Actions */}
+            <div className="border-t border-[#40E0D0]/20 p-4 flex gap-3 flex-wrap">
+              {/* Screen reader announcements for copy actions */}
+              <div role="status" aria-live="polite" className="sr-only">
+                {copied && "Code copied to clipboard"}
+                {copiedClaude && "Prompt copied to clipboard for Claude"}
+              </div>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={handleCopy}
+                className="border-[#40E0D0]/30 text-[#FAEBD7] hover:bg-[#40E0D0]/20 hover:text-[#FAEBD7]"
+                aria-label={copied ? "Code copied" : "Copy code to clipboard"}
+              >
+                {copied ? (
+                  <>
+                    <Check className="w-4 h-4 mr-2 text-green-400" aria-hidden="true" />
+                    Copied!
+                  </>
+                ) : (
+                  <>
+                    <Copy className="w-4 h-4 mr-2" aria-hidden="true" />
+                    Copy Code
+                  </>
+                )}
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={handleCopyToClaude}
+                className="border-[#FF6347]/30 text-[#FAEBD7] hover:bg-[#FF6347]/20 hover:text-[#FAEBD7]"
+                aria-label={copiedClaude ? "Prompt copied for Claude" : "Copy prompt to clipboard for Claude"}
+              >
+                {copiedClaude ? (
+                  <>
+                    <Check className="w-4 h-4 mr-2 text-green-400" aria-hidden="true" />
+                    Copied for Claude!
+                  </>
+                ) : (
+                  <>
+                    <Sparkles className="w-4 h-4 mr-2 text-[#FF6347]" aria-hidden="true" />
+                    Copy to Claude
+                  </>
+                )}
+              </Button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/components/landing/index.ts
+++ b/components/landing/index.ts
@@ -1,2 +1,8 @@
 export { Hero } from './Hero'
 export { Footer } from './Footer'
+export { QuickStart } from './QuickStart'
+export { PricingTeaser } from './PricingTeaser'
+export { EnrichmentFeature } from './EnrichmentFeature'
+export { EnrichmentAgents } from './EnrichmentAgents'
+export { ContentGeneration } from './ContentGeneration'
+export { CtaBand } from './CtaBand'


### PR DESCRIPTION
## Summary
- Ports remaining landing page components from turquoise-koala repository
- Adds QuickStart, PricingTeaser, EnrichmentFeature, EnrichmentAgents, ContentGeneration, and CtaBand components
- All components adapted for Next.js 15 with "use client" directives where needed

## Components Added
| Component | Description |
|-----------|-------------|
| QuickStart | Code examples with language tabs (cURL, JS, Python) |
| PricingTeaser | Three pricing tier cards with cost-plus explanation |
| EnrichmentFeature | Tabbed data display (Fields/JSON/Audit) |
| EnrichmentAgents | Testimonial/social proof section |
| ContentGeneration | Draft editor preview with A/B/C tabs |
| CtaBand | Call-to-action band with multiple CTAs |

## Addresses Issues
- Addresses #13 (Port QuickStart, Features, and PricingTeaser sections)
- Contributes to Epic #8 (Theme & Landing Page)

## Test Plan
- [x] `npm run build` passes successfully
- [x] TypeScript compiles without errors
- [ ] Manual testing of components on landing page

🤖 Generated with [Claude Code](https://claude.com/claude-code)