### PR TITLE
feat(settings): Implement real LinkedIn and HubSpot integrations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,18 @@
+# Clerk Authentication Configuration
+# Get keys from https://dashboard.clerk.com
+NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_your_publishable_key
+CLERK_SECRET_KEY=sk_test_your_secret_key
+
+# Clerk URLs
+NEXT_PUBLIC_CLERK_SIGN_IN_URL=/sign-in
+NEXT_PUBLIC_CLERK_SIGN_UP_URL=/sign-up
+NEXT_PUBLIC_CLERK_AFTER_SIGN_IN_URL=/dashboard
+NEXT_PUBLIC_CLERK_AFTER_SIGN_UP_URL=/dashboard
+
+# Kong Admin API (for API key management)
+KONG_ADMIN_URL=http://localhost:8001
+KONG_PROXY_URL=http://localhost:8000
+
+# ABM.dev API Gateway (for LinkedIn/HubSpot integrations)
+# This is the Zuplo gateway URL that proxies to the abm.dev-platform backend
+NEXT_PUBLIC_API_GATEWAY_URL=https://turquoise-koala-main-cae84bb.zuplo.app

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/app/(protected)/settings/hubspot/page.tsx
+++ b/app/(protected)/settings/hubspot/page.tsx
@@ -1,55 +1,17 @@
-'use client'
+'use client';
 
-import { useState } from 'react'
-import { Badge } from '@/components/ui/badge'
-import { Button } from '@/components/ui/button'
-import {
-  Database,
-  Check,
-  RefreshCw,
-  Unlink,
-  ArrowRightLeft,
-  History,
-  AlertCircle,
-} from 'lucide-react'
+import { useAuth, useOrganization } from '@clerk/nextjs';
+import { useEffect, useState } from 'react';
+import { HubSpotSettingsCard } from '@/components/settings/HubSpotSettingsCard';
 
 export default function HubSpotSettingsPage() {
-  // Mock state - in production this would come from API
-  const [isConnected, setIsConnected] = useState(false)
-  const [isLoading, setIsLoading] = useState(false)
+  const { getToken } = useAuth();
+  const { organization } = useOrganization();
+  const [token, setToken] = useState<string>();
 
-  // Mock connected portal data
-  const connectedPortal = {
-    portalId: '12345678',
-    portalName: 'Acme Corp',
-    hubDomain: 'acme-corp.hubspot.com',
-    connectedAt: '2024-01-10',
-    lastSync: '2024-01-20T14:30:00Z',
-  }
-
-  // Mock sync history
-  const syncHistory = [
-    { date: '2024-01-20 14:30', type: 'Contacts', count: 150, status: 'success' },
-    { date: '2024-01-20 14:00', type: 'Companies', count: 42, status: 'success' },
-    { date: '2024-01-19 10:15', type: 'Deals', count: 28, status: 'success' },
-    { date: '2024-01-18 09:00', type: 'Contacts', count: 0, status: 'error' },
-  ]
-
-  const handleConnect = async () => {
-    setIsLoading(true)
-    // Simulate API call
-    await new Promise((resolve) => setTimeout(resolve, 1500))
-    setIsConnected(true)
-    setIsLoading(false)
-  }
-
-  const handleDisconnect = async () => {
-    setIsLoading(true)
-    // Simulate API call
-    await new Promise((resolve) => setTimeout(resolve, 1000))
-    setIsConnected(false)
-    setIsLoading(false)
-  }
+  useEffect(() => {
+    getToken().then((t) => t && setToken(t));
+  }, [getToken]);
 
   return (
     <div className="space-y-8">
@@ -66,191 +28,39 @@ export default function HubSpotSettingsPage() {
         </p>
       </div>
 
-      {/* Connection Status Card */}
+      {/* HubSpot Settings Card */}
+      <HubSpotSettingsCard token={token} orgId={organization?.id} />
+
+      {/* Additional Info */}
       <div className="p-6 rounded-lg bg-[var(--navy)] border border-[var(--turquoise)]/20">
-        <div className="flex items-center justify-between mb-6">
-          <div className="flex items-center gap-4">
-            <div className="p-3 rounded-lg bg-[#FF7A59]/10">
-              <Database className="w-8 h-8 text-[#FF7A59]" />
-            </div>
-            <div>
-              <h2 className="text-lg font-medium text-[var(--cream)]">
-                HubSpot CRM
-              </h2>
-              <p className="text-sm text-[var(--cream)]/60">
-                {isConnected
-                  ? `Connected to ${connectedPortal.portalName}`
-                  : 'Connect to sync your CRM data'}
-              </p>
-            </div>
-          </div>
-          <Badge variant={isConnected ? 'success' : 'warning'}>
-            {isConnected ? 'Connected' : 'Not Connected'}
-          </Badge>
-        </div>
-
-        {isConnected ? (
-          <div className="space-y-4">
-            {/* Connected Portal Info */}
-            <div className="p-4 rounded-lg bg-[var(--turquoise)]/5 border border-[var(--turquoise)]/10">
-              <div className="flex items-center justify-between">
-                <div>
-                  <p className="text-[var(--cream)] font-medium">
-                    {connectedPortal.portalName}
-                  </p>
-                  <p className="text-sm text-[var(--cream)]/60">
-                    Portal ID: {connectedPortal.portalId}
-                  </p>
-                  <p className="text-xs text-[var(--cream)]/40 mt-1">
-                    Last synced: {new Date(connectedPortal.lastSync).toLocaleString()}
-                  </p>
-                </div>
-                <div className="flex gap-2">
-                  <Button variant="outline" size="sm" disabled={isLoading}>
-                    <RefreshCw className="w-4 h-4 mr-2" />
-                    Sync Now
-                  </Button>
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={handleDisconnect}
-                    disabled={isLoading}
-                    className="border-red-500/50 text-red-400 hover:bg-red-500/10"
-                  >
-                    <Unlink className="w-4 h-4 mr-2" />
-                    Disconnect
-                  </Button>
-                </div>
-              </div>
-            </div>
-          </div>
-        ) : (
-          <div className="space-y-4">
-            <p className="text-sm text-[var(--cream)]/60">
-              Connect your HubSpot CRM to unlock these features:
-            </p>
-            <ul className="space-y-2">
-              {[
-                'Two-way contact synchronization',
-                'Automatic deal and pipeline updates',
-                'Company data enrichment',
-                'Activity tracking and logging',
-              ].map((feature) => (
-                <li
-                  key={feature}
-                  className="flex items-center gap-2 text-sm text-[var(--cream)]/70"
-                >
-                  <Check className="w-4 h-4 text-[var(--turquoise)]" />
-                  {feature}
-                </li>
-              ))}
-            </ul>
-            <Button
-              onClick={handleConnect}
-              disabled={isLoading}
-              className="mt-4 bg-[#FF7A59] hover:bg-[#FF7A59]/90 text-white"
-            >
-              {isLoading ? (
-                <>
-                  <RefreshCw className="w-4 h-4 mr-2 animate-spin" />
-                  Connecting...
-                </>
-              ) : (
-                <>
-                  <Database className="w-4 h-4 mr-2" />
-                  Connect HubSpot
-                </>
-              )}
-            </Button>
-          </div>
-        )}
-      </div>
-
-      {/* Field Mapping Card */}
-      <div className="p-6 rounded-lg bg-[var(--navy)] border border-[var(--turquoise)]/20">
-        <div className="flex items-center gap-3 mb-6">
-          <ArrowRightLeft className="w-5 h-5 text-[var(--turquoise)]" />
-          <h2 className="text-lg font-medium text-[var(--cream)]">Field Mapping</h2>
-        </div>
-
-        <div className="space-y-3">
-          {[
-            { local: 'First Name', hubspot: 'firstname', synced: true },
-            { local: 'Last Name', hubspot: 'lastname', synced: true },
-            { local: 'Email', hubspot: 'email', synced: true },
-            { local: 'Company', hubspot: 'company', synced: true },
-            { local: 'Job Title', hubspot: 'jobtitle', synced: false },
-            { local: 'Phone', hubspot: 'phone', synced: false },
-          ].map((mapping) => (
-            <div
-              key={mapping.local}
-              className="flex items-center justify-between p-3 rounded-lg bg-[var(--turquoise)]/5 border border-[var(--turquoise)]/10"
-            >
-              <div className="flex items-center gap-4">
-                <span className="text-[var(--cream)] w-32">{mapping.local}</span>
-                <ArrowRightLeft className="w-4 h-4 text-[var(--cream)]/40" />
-                <span className="text-[var(--cream)]/60 font-mono text-sm">
-                  {mapping.hubspot}
-                </span>
-              </div>
-              <label className="flex items-center gap-2 cursor-pointer">
-                <span className="text-sm text-[var(--cream)]/60">Sync</span>
-                <input
-                  type="checkbox"
-                  defaultChecked={mapping.synced}
-                  disabled={!isConnected}
-                  className="w-5 h-5 rounded border-[var(--turquoise)]/30 text-[var(--turquoise)] focus:ring-[var(--turquoise)] focus:ring-offset-0 bg-transparent disabled:opacity-50"
-                />
-              </label>
-            </div>
-          ))}
-        </div>
-
-        {!isConnected && (
-          <p className="mt-4 text-sm text-[var(--cream)]/50 italic">
-            Connect your HubSpot account to configure field mapping.
+        <h2 className="text-lg font-medium text-[var(--cream)] mb-4">
+          Setting up HubSpot
+        </h2>
+        <div className="space-y-4 text-sm text-[var(--cream)]/70">
+          <p>
+            To connect HubSpot, you need to create a Private App in your HubSpot
+            account. This gives you a secure access token that we use to sync data.
           </p>
-        )}
-      </div>
-
-      {/* Sync History Card */}
-      <div className="p-6 rounded-lg bg-[var(--navy)] border border-[var(--turquoise)]/20">
-        <div className="flex items-center gap-3 mb-6">
-          <History className="w-5 h-5 text-[var(--turquoise)]" />
-          <h2 className="text-lg font-medium text-[var(--cream)]">Sync History</h2>
-        </div>
-
-        {isConnected ? (
           <div className="space-y-2">
-            {syncHistory.map((sync, index) => (
-              <div
-                key={index}
-                className="flex items-center justify-between p-3 rounded-lg bg-[var(--turquoise)]/5 border border-[var(--turquoise)]/10"
-              >
-                <div className="flex items-center gap-4">
-                  <span className="text-sm text-[var(--cream)]/60">{sync.date}</span>
-                  <span className="text-[var(--cream)]">{sync.type}</span>
-                  <span className="text-sm text-[var(--cream)]/60">
-                    {sync.count} records
-                  </span>
-                </div>
-                {sync.status === 'success' ? (
-                  <Badge variant="success">Success</Badge>
-                ) : (
-                  <Badge variant="error">
-                    <AlertCircle className="w-3 h-3 mr-1" />
-                    Failed
-                  </Badge>
-                )}
-              </div>
-            ))}
+            <h3 className="font-medium text-[var(--cream)]">Required scopes:</h3>
+            <ul className="list-disc list-inside space-y-1 ml-2">
+              <li>crm.objects.contacts.read</li>
+              <li>crm.objects.contacts.write</li>
+              <li>crm.objects.companies.read</li>
+              <li>crm.objects.companies.write</li>
+            </ul>
           </div>
-        ) : (
-          <p className="text-sm text-[var(--cream)]/50 italic">
-            Connect your HubSpot account to view sync history.
-          </p>
-        )}
+          <div className="space-y-2">
+            <h3 className="font-medium text-[var(--cream)]">What we sync:</h3>
+            <ul className="list-disc list-inside space-y-1 ml-2">
+              <li>Contact information (name, email, phone)</li>
+              <li>Company data (name, domain, industry)</li>
+              <li>Enriched profile data from LinkedIn</li>
+              <li>Custom properties for ABM scoring</li>
+            </ul>
+          </div>
+        </div>
       </div>
     </div>
-  )
+  );
 }

--- a/app/(protected)/settings/linkedin/page.tsx
+++ b/app/(protected)/settings/linkedin/page.tsx
@@ -1,38 +1,17 @@
-'use client'
+'use client';
 
-import { useState } from 'react'
-import { Badge } from '@/components/ui/badge'
-import { Button } from '@/components/ui/button'
-import { Linkedin, Check, RefreshCw, Unlink, Settings2 } from 'lucide-react'
+import { useAuth, useOrganization } from '@clerk/nextjs';
+import { useEffect, useState } from 'react';
+import { LinkedInSettingsCard } from '@/components/settings/LinkedInSettingsCard';
 
 export default function LinkedInSettingsPage() {
-  // Mock state - in production this would come from API
-  const [isConnected, setIsConnected] = useState(false)
-  const [isLoading, setIsLoading] = useState(false)
+  const { getToken } = useAuth();
+  const { organization } = useOrganization();
+  const [token, setToken] = useState<string>();
 
-  // Mock connected account data
-  const connectedAccount = {
-    name: 'John Doe',
-    email: 'john@company.com',
-    profileUrl: 'https://linkedin.com/in/johndoe',
-    connectedAt: '2024-01-15',
-  }
-
-  const handleConnect = async () => {
-    setIsLoading(true)
-    // Simulate API call
-    await new Promise((resolve) => setTimeout(resolve, 1500))
-    setIsConnected(true)
-    setIsLoading(false)
-  }
-
-  const handleDisconnect = async () => {
-    setIsLoading(true)
-    // Simulate API call
-    await new Promise((resolve) => setTimeout(resolve, 1000))
-    setIsConnected(false)
-    setIsLoading(false)
-  }
+  useEffect(() => {
+    getToken().then((t) => t && setToken(t));
+  }, [getToken]);
 
   return (
     <div className="space-y-8">
@@ -49,164 +28,40 @@ export default function LinkedInSettingsPage() {
         </p>
       </div>
 
-      {/* Connection Status Card */}
+      {/* LinkedIn Settings Card */}
+      <LinkedInSettingsCard token={token} orgId={organization?.id} />
+
+      {/* Additional Info */}
       <div className="p-6 rounded-lg bg-[var(--navy)] border border-[var(--turquoise)]/20">
-        <div className="flex items-center justify-between mb-6">
-          <div className="flex items-center gap-4">
-            <div className="p-3 rounded-lg bg-[#0A66C2]/10">
-              <Linkedin className="w-8 h-8 text-[#0A66C2]" />
-            </div>
-            <div>
-              <h2 className="text-lg font-medium text-[var(--cream)]">
-                LinkedIn Account
-              </h2>
-              <p className="text-sm text-[var(--cream)]/60">
-                {isConnected
-                  ? 'Your LinkedIn account is connected'
-                  : 'Connect to enable profile enrichment'}
-              </p>
-            </div>
-          </div>
-          <Badge variant={isConnected ? 'success' : 'warning'}>
-            {isConnected ? 'Connected' : 'Not Connected'}
-          </Badge>
-        </div>
-
-        {isConnected ? (
-          <div className="space-y-4">
-            {/* Connected Account Info */}
-            <div className="p-4 rounded-lg bg-[var(--turquoise)]/5 border border-[var(--turquoise)]/10">
-              <div className="flex items-center justify-between">
-                <div>
-                  <p className="text-[var(--cream)] font-medium">
-                    {connectedAccount.name}
-                  </p>
-                  <p className="text-sm text-[var(--cream)]/60">
-                    {connectedAccount.email}
-                  </p>
-                  <p className="text-xs text-[var(--cream)]/40 mt-1">
-                    Connected on {new Date(connectedAccount.connectedAt).toLocaleDateString()}
-                  </p>
-                </div>
-                <div className="flex gap-2">
-                  <Button variant="outline" size="sm" disabled={isLoading}>
-                    <RefreshCw className="w-4 h-4 mr-2" />
-                    Refresh
-                  </Button>
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={handleDisconnect}
-                    disabled={isLoading}
-                    className="border-red-500/50 text-red-400 hover:bg-red-500/10"
-                  >
-                    <Unlink className="w-4 h-4 mr-2" />
-                    Disconnect
-                  </Button>
-                </div>
-              </div>
-            </div>
-          </div>
-        ) : (
-          <div className="space-y-4">
-            <p className="text-sm text-[var(--cream)]/60">
-              Connect your LinkedIn account to unlock powerful features:
-            </p>
-            <ul className="space-y-2">
-              {[
-                'Automatically enrich contact profiles',
-                'Track company and prospect updates',
-                'Import connections as leads',
-                'Sync activities and engagement',
-              ].map((feature) => (
-                <li
-                  key={feature}
-                  className="flex items-center gap-2 text-sm text-[var(--cream)]/70"
-                >
-                  <Check className="w-4 h-4 text-[var(--turquoise)]" />
-                  {feature}
-                </li>
-              ))}
-            </ul>
-            <Button
-              onClick={handleConnect}
-              disabled={isLoading}
-              className="mt-4 bg-[#0A66C2] hover:bg-[#0A66C2]/90 text-white"
-            >
-              {isLoading ? (
-                <>
-                  <RefreshCw className="w-4 h-4 mr-2 animate-spin" />
-                  Connecting...
-                </>
-              ) : (
-                <>
-                  <Linkedin className="w-4 h-4 mr-2" />
-                  Connect LinkedIn
-                </>
-              )}
-            </Button>
-          </div>
-        )}
-      </div>
-
-      {/* Sync Settings Card */}
-      <div className="p-6 rounded-lg bg-[var(--navy)] border border-[var(--turquoise)]/20">
-        <div className="flex items-center gap-3 mb-6">
-          <Settings2 className="w-5 h-5 text-[var(--turquoise)]" />
-          <h2 className="text-lg font-medium text-[var(--cream)]">Sync Settings</h2>
-        </div>
-
-        <div className="space-y-4">
-          {[
-            {
-              id: 'auto-enrich',
-              label: 'Auto-enrich new contacts',
-              description: 'Automatically fetch LinkedIn data for new contacts',
-              defaultChecked: true,
-            },
-            {
-              id: 'sync-activities',
-              label: 'Sync engagement activities',
-              description: 'Track LinkedIn interactions and messages',
-              defaultChecked: true,
-            },
-            {
-              id: 'company-updates',
-              label: 'Monitor company updates',
-              description: 'Get notified about changes at target companies',
-              defaultChecked: false,
-            },
-            {
-              id: 'import-connections',
-              label: 'Import LinkedIn connections',
-              description: 'Automatically add your connections as leads',
-              defaultChecked: false,
-            },
-          ].map((setting) => (
-            <label
-              key={setting.id}
-              className="flex items-center justify-between p-4 rounded-lg bg-[var(--turquoise)]/5 border border-[var(--turquoise)]/10 cursor-pointer hover:border-[var(--turquoise)]/20 transition-colors"
-            >
-              <div>
-                <p className="text-[var(--cream)]">{setting.label}</p>
-                <p className="text-sm text-[var(--cream)]/60">{setting.description}</p>
-              </div>
-              <input
-                type="checkbox"
-                defaultChecked={setting.defaultChecked}
-                disabled={!isConnected}
-                className="w-5 h-5 rounded border-[var(--turquoise)]/30 text-[var(--turquoise)] focus:ring-[var(--turquoise)] focus:ring-offset-0 bg-transparent disabled:opacity-50"
-              />
-            </label>
-          ))}
-        </div>
-
-        {!isConnected && (
-          <p className="mt-4 text-sm text-[var(--cream)]/50 italic">
-            Connect your LinkedIn account to configure sync settings.
+        <h2 className="text-lg font-medium text-[var(--cream)] mb-4">
+          How it works
+        </h2>
+        <div className="space-y-4 text-sm text-[var(--cream)]/70">
+          <p>
+            When you connect your LinkedIn account, we use Browserbase to securely
+            authenticate your session. This allows us to enrich your contacts with
+            real-time LinkedIn profile data.
           </p>
-        )}
+          <div className="space-y-2">
+            <h3 className="font-medium text-[var(--cream)]">What we access:</h3>
+            <ul className="list-disc list-inside space-y-1 ml-2">
+              <li>Public profile information</li>
+              <li>Work history and education</li>
+              <li>Skills and endorsements</li>
+              <li>Company associations</li>
+            </ul>
+          </div>
+          <div className="space-y-2">
+            <h3 className="font-medium text-[var(--cream)]">What we never do:</h3>
+            <ul className="list-disc list-inside space-y-1 ml-2">
+              <li>Send messages on your behalf</li>
+              <li>Make connection requests</li>
+              <li>Access your direct messages</li>
+              <li>Store your LinkedIn password</li>
+            </ul>
+          </div>
+        </div>
       </div>
     </div>
-  )
+  );
 }

--- a/components/settings/ConnectHubSpotModal.tsx
+++ b/components/settings/ConnectHubSpotModal.tsx
@@ -1,0 +1,224 @@
+'use client';
+
+import React, { useState, useMemo } from 'react';
+import * as Dialog from '@radix-ui/react-dialog';
+import { Button } from '@/components/ui/button';
+import { Loader2, AlertCircle, CheckCircle2, Eye, EyeOff, ExternalLink } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { createApiClient } from '@/lib/api-client';
+
+type ConnectionState = 'idle' | 'connecting' | 'connected' | 'error';
+
+// HubSpot logo SVG icon component
+export function HubSpotIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="currentColor">
+      <path d="M18.164 7.93V5.086a2.198 2.198 0 0 0 1.267-1.978V3.06a2.198 2.198 0 0 0-2.198-2.198h-.048a2.198 2.198 0 0 0-2.198 2.198v.048a2.198 2.198 0 0 0 1.267 1.978V7.93a5.996 5.996 0 0 0-2.77 1.29L6.164 3.71a2.43 2.43 0 1 0-1.358 1.13l7.26 5.418a6.002 6.002 0 0 0 .084 6.53l-2.18 2.18a1.835 1.835 0 1 0 1.13 1.13l2.18-2.18a6.002 6.002 0 0 0 6.53.084 6.002 6.002 0 0 0-1.646-10.072Zm-.979 8.059a3.453 3.453 0 1 1 0-6.905 3.453 3.453 0 0 1 0 6.905Z"/>
+    </svg>
+  );
+}
+
+interface ConnectResponse {
+  id: string;
+  integration_type: string;
+  is_active: boolean;
+  created_at: string;
+}
+
+interface ConnectHubSpotModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSuccess: () => void;
+  token?: string;
+  orgId?: string;
+}
+
+export function ConnectHubSpotModal({
+  open,
+  onOpenChange,
+  onSuccess,
+  token,
+  orgId,
+}: ConnectHubSpotModalProps) {
+  const [state, setState] = useState<ConnectionState>('idle');
+  const [accessToken, setAccessToken] = useState('');
+  const [showToken, setShowToken] = useState(false);
+  const [errorMessage, setErrorMessage] = useState('');
+
+  // Create API client with auth context
+  const api = useMemo(() => createApiClient(token, orgId), [token, orgId]);
+
+  const validateToken = (tokenValue: string): boolean => {
+    // HubSpot Private App tokens start with 'pat-' followed by region code
+    // e.g., pat-na1-xxx or pat-eu1-xxx
+    return /^pat-(na1|eu1|ap1)-[a-f0-9-]+$/i.test(tokenValue) || tokenValue.length > 20;
+  };
+
+  const handleConnect = async () => {
+    if (!accessToken.trim()) {
+      setErrorMessage('Please enter your HubSpot access token');
+      return;
+    }
+
+    if (!validateToken(accessToken)) {
+      setErrorMessage('Invalid token format. HubSpot Private App tokens usually start with "pat-"');
+      return;
+    }
+
+    setState('connecting');
+    setErrorMessage('');
+
+    try {
+      const result = await api.post<ConnectResponse>('/v1/crm/config/integrations', {
+        integration_type: 'hubspot',
+        display_name: 'HubSpot',
+        api_key: accessToken,
+        is_active: true,
+      });
+
+      if (!result.success) {
+        throw new Error(result.error?.message || 'Failed to connect to HubSpot');
+      }
+
+      setState('connected');
+      setTimeout(() => {
+        onSuccess();
+        onOpenChange(false);
+        resetModal();
+      }, 1500);
+    } catch (error) {
+      setState('error');
+      setErrorMessage(error instanceof Error ? error.message : 'An error occurred');
+    }
+  };
+
+  const resetModal = () => {
+    setState('idle');
+    setAccessToken('');
+    setShowToken(false);
+    setErrorMessage('');
+  };
+
+  const handleClose = () => {
+    if (state !== 'connecting') {
+      onOpenChange(false);
+      resetModal();
+    }
+  };
+
+  return (
+    <Dialog.Root open={open} onOpenChange={handleClose}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 bg-black/50 backdrop-blur-sm z-50" />
+        <Dialog.Content
+          className={cn(
+            "fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 z-50",
+            "bg-[var(--navy)] border border-[var(--turquoise)]/20 rounded-lg shadow-xl",
+            "w-full max-w-md p-6",
+            "focus:outline-none"
+          )}
+        >
+          <Dialog.Title className="text-xl font-semibold text-[var(--cream)] mb-2 flex items-center gap-2">
+            <HubSpotIcon className="size-6 text-[#ff7a59]" />
+            Connect HubSpot Account
+          </Dialog.Title>
+
+          <Dialog.Description className="text-sm text-[var(--cream)]/70 mb-6">
+            {state === 'idle' && 'Enter your HubSpot Private App access token to connect your account.'}
+            {state === 'connecting' && 'Connecting to HubSpot...'}
+            {state === 'connected' && 'Successfully connected your HubSpot account!'}
+            {state === 'error' && 'An error occurred while connecting your account.'}
+          </Dialog.Description>
+
+          <div className="space-y-4">
+            {(state === 'idle' || state === 'error') && (
+              <>
+                <div className="space-y-2">
+                  <label htmlFor="hubspot-token" className="text-sm font-medium text-[var(--cream)]">
+                    Access Token
+                  </label>
+                  <div className="relative">
+                    <input
+                      id="hubspot-token"
+                      type={showToken ? 'text' : 'password'}
+                      value={accessToken}
+                      onChange={(e) => setAccessToken(e.target.value)}
+                      placeholder="pat-na1-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+                      className={cn(
+                        "w-full px-3 py-2 pr-10 rounded-md font-mono text-sm",
+                        "bg-[var(--dark-blue)] border border-[var(--turquoise)]/20",
+                        "text-[var(--cream)] placeholder:text-[var(--cream)]/40",
+                        "focus:outline-none focus:ring-2 focus:ring-[var(--turquoise)]/50"
+                      )}
+                    />
+                    <button
+                      type="button"
+                      onClick={() => setShowToken(!showToken)}
+                      className="absolute right-2 top-1/2 -translate-y-1/2 text-[var(--cream)]/60 hover:text-[var(--cream)]"
+                    >
+                      {showToken ? <EyeOff className="size-4" /> : <Eye className="size-4" />}
+                    </button>
+                  </div>
+                  <p className="text-xs text-[var(--cream)]/50">
+                    Get your access token from{' '}
+                    <a
+                      href="https://developers.hubspot.com/docs/api/private-apps"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-[var(--turquoise)] hover:underline inline-flex items-center gap-0.5"
+                    >
+                      HubSpot Private Apps
+                      <ExternalLink className="size-3" />
+                    </a>
+                  </p>
+                </div>
+
+                {state === 'error' && errorMessage && (
+                  <div className="bg-red-500/10 border border-red-500/30 rounded-md p-4 flex items-start gap-3">
+                    <AlertCircle className="size-5 text-red-500 shrink-0 mt-0.5" />
+                    <p className="text-sm text-red-500">{errorMessage}</p>
+                  </div>
+                )}
+              </>
+            )}
+
+            {state === 'connected' && (
+              <div className="bg-green-500/10 border border-green-500/30 rounded-md p-4 flex items-center gap-3">
+                <CheckCircle2 className="size-5 text-green-500" />
+                <p className="text-sm text-green-500">Connection verified successfully!</p>
+              </div>
+            )}
+
+            <div className="flex gap-3">
+              {(state === 'idle' || state === 'error') && (
+                <>
+                  <Button variant="outline" onClick={handleClose} className="flex-1">
+                    Cancel
+                  </Button>
+                  <Button onClick={handleConnect} className="flex-1 bg-[#ff7a59] hover:bg-[#e86a4a]">
+                    <HubSpotIcon className="size-4 mr-2" />
+                    Connect
+                  </Button>
+                </>
+              )}
+
+              {state === 'connecting' && (
+                <Button disabled className="w-full">
+                  <Loader2 className="animate-spin size-4 mr-2" />
+                  Connecting...
+                </Button>
+              )}
+
+              {state === 'connected' && (
+                <Button disabled className="w-full bg-green-500">
+                  <CheckCircle2 className="size-4 mr-2" />
+                  Connected
+                </Button>
+              )}
+            </div>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/components/settings/ConnectLinkedInModal.tsx
+++ b/components/settings/ConnectLinkedInModal.tsx
@@ -1,0 +1,227 @@
+'use client';
+
+import React, { useState, useMemo } from 'react';
+import * as Dialog from '@radix-ui/react-dialog';
+import { Button } from '@/components/ui/button';
+import { Linkedin, Loader2, AlertCircle, CheckCircle2, ExternalLink } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { createApiClient } from '@/lib/api-client';
+
+type ConnectionState = 'idle' | 'initializing' | 'waiting' | 'verifying' | 'connected' | 'error';
+
+interface InitializeResponse {
+  sessionId: string;
+  sessionUrl: string;
+  status: string;
+  message?: string;
+}
+
+interface VerifyResponse {
+  success: boolean;
+  status: string;
+  message?: string;
+}
+
+interface ConnectLinkedInModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSuccess: () => void;
+  token?: string;
+  orgId?: string;
+}
+
+export function ConnectLinkedInModal({
+  open,
+  onOpenChange,
+  onSuccess,
+  token,
+  orgId,
+}: ConnectLinkedInModalProps) {
+  const [state, setState] = useState<ConnectionState>('idle');
+  const [sessionUrl, setSessionUrl] = useState<string>('');
+  const [sessionId, setSessionId] = useState<string>('');
+  const [errorMessage, setErrorMessage] = useState<string>('');
+
+  // Create API client with auth context
+  const api = useMemo(() => createApiClient(token, orgId), [token, orgId]);
+
+  const handleInitialize = async () => {
+    setState('initializing');
+    setErrorMessage('');
+
+    try {
+      const result = await api.post<InitializeResponse>('/v1/linkedin-connection/initialize');
+
+      if (!result.success || !result.data) {
+        throw new Error(result.error?.message || 'Failed to initialize connection');
+      }
+
+      setSessionId(result.data.sessionId);
+      setSessionUrl(result.data.sessionUrl);
+      setState('waiting');
+
+      // Open Browserbase Live View in new window
+      window.open(result.data.sessionUrl, '_blank', 'noopener,noreferrer');
+    } catch (error) {
+      setState('error');
+      setErrorMessage(error instanceof Error ? error.message : 'An error occurred');
+    }
+  };
+
+  const handleVerify = async () => {
+    setState('verifying');
+    setErrorMessage('');
+
+    try {
+      const result = await api.post<VerifyResponse>('/v1/linkedin-connection/verify', { sessionId });
+
+      if (!result.success || !result.data?.success) {
+        throw new Error(result.error?.message || result.data?.message || 'Failed to verify connection');
+      }
+
+      setState('connected');
+      setTimeout(() => {
+        onSuccess();
+        onOpenChange(false);
+        resetModal();
+      }, 1500);
+    } catch (error) {
+      setState('error');
+      setErrorMessage(error instanceof Error ? error.message : 'Verification failed');
+    }
+  };
+
+  const resetModal = () => {
+    setState('idle');
+    setSessionUrl('');
+    setSessionId('');
+    setErrorMessage('');
+  };
+
+  const handleClose = () => {
+    if (state !== 'verifying' && state !== 'initializing') {
+      onOpenChange(false);
+      resetModal();
+    }
+  };
+
+  return (
+    <Dialog.Root open={open} onOpenChange={handleClose}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 bg-black/50 backdrop-blur-sm z-50" />
+        <Dialog.Content
+          className={cn(
+            "fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 z-50",
+            "bg-[var(--navy)] border border-[var(--turquoise)]/20 rounded-lg shadow-xl",
+            "w-full max-w-md p-6",
+            "focus:outline-none"
+          )}
+        >
+          <Dialog.Title className="text-xl font-semibold text-[var(--cream)] mb-2 flex items-center gap-2">
+            <Linkedin className="size-6 text-[var(--turquoise)]" />
+            Connect LinkedIn Account
+          </Dialog.Title>
+
+          <Dialog.Description className="text-sm text-[var(--cream)]/70 mb-6">
+            {state === 'idle' && 'Connect your LinkedIn account to enable profile data enrichment for your contacts.'}
+            {state === 'initializing' && 'Initializing secure browser session...'}
+            {state === 'waiting' && 'Please log in to LinkedIn in the new window, then click "I\'m Done" below.'}
+            {state === 'verifying' && 'Verifying your LinkedIn connection...'}
+            {state === 'connected' && 'Successfully connected your LinkedIn account!'}
+            {state === 'error' && 'An error occurred while connecting your account.'}
+          </Dialog.Description>
+
+          <div className="space-y-4">
+            {state === 'waiting' && sessionUrl && (
+              <div className="bg-[var(--dark-blue)]/50 border border-[var(--turquoise)]/20 rounded-md p-4">
+                <p className="text-sm text-[var(--cream)]/70 mb-3">
+                  A new window has been opened. Please log in to LinkedIn.
+                </p>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => window.open(sessionUrl, '_blank', 'noopener,noreferrer')}
+                  className="w-full"
+                >
+                  <ExternalLink className="size-4 mr-2" />
+                  Reopen Login Window
+                </Button>
+              </div>
+            )}
+
+            {state === 'error' && errorMessage && (
+              <div className="bg-red-500/10 border border-red-500/30 rounded-md p-4 flex items-start gap-3">
+                <AlertCircle className="size-5 text-red-500 shrink-0 mt-0.5" />
+                <p className="text-sm text-red-500">{errorMessage}</p>
+              </div>
+            )}
+
+            {state === 'connected' && (
+              <div className="bg-green-500/10 border border-green-500/30 rounded-md p-4 flex items-center gap-3">
+                <CheckCircle2 className="size-5 text-green-500" />
+                <p className="text-sm text-green-500">Connection verified successfully!</p>
+              </div>
+            )}
+
+            <div className="flex gap-3">
+              {state === 'idle' && (
+                <>
+                  <Button variant="outline" onClick={handleClose} className="flex-1">
+                    Cancel
+                  </Button>
+                  <Button onClick={handleInitialize} className="flex-1">
+                    <Linkedin className="size-4 mr-2" />
+                    Start Connection
+                  </Button>
+                </>
+              )}
+
+              {state === 'initializing' && (
+                <Button disabled className="w-full">
+                  <Loader2 className="animate-spin size-4 mr-2" />
+                  Initializing...
+                </Button>
+              )}
+
+              {state === 'waiting' && (
+                <>
+                  <Button variant="outline" onClick={handleClose} className="flex-1">
+                    Cancel
+                  </Button>
+                  <Button onClick={handleVerify} className="flex-1">
+                    I&apos;m Done
+                  </Button>
+                </>
+              )}
+
+              {state === 'verifying' && (
+                <Button disabled className="w-full">
+                  <Loader2 className="animate-spin size-4 mr-2" />
+                  Verifying...
+                </Button>
+              )}
+
+              {state === 'error' && (
+                <>
+                  <Button variant="outline" onClick={handleClose} className="flex-1">
+                    Cancel
+                  </Button>
+                  <Button onClick={handleInitialize} className="flex-1">
+                    Try Again
+                  </Button>
+                </>
+              )}
+
+              {state === 'connected' && (
+                <Button disabled className="w-full">
+                  <CheckCircle2 className="size-4 mr-2" />
+                  Connected
+                </Button>
+              )}
+            </div>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/components/settings/HubSpotSettingsCard.tsx
+++ b/components/settings/HubSpotSettingsCard.tsx
@@ -1,0 +1,207 @@
+'use client';
+
+import React, { useState, useMemo } from 'react';
+import { Button } from '@/components/ui/button';
+import { ConnectHubSpotModal, HubSpotIcon } from './ConnectHubSpotModal';
+import { useHubSpotStatus } from '@/lib/hooks/useHubSpotStatus';
+import { ExternalLink, Loader2 } from 'lucide-react';
+import { Skeleton } from '@/components/ui/skeleton';
+import { EmptyStateHubSpotNotConnected } from '@/components/ui/empty-state';
+import { createApiClient } from '@/lib/api-client';
+import { Badge } from '@/components/ui/badge';
+
+// Status badge component
+function HubSpotStatusBadge({ status }: { status: string }) {
+  const variants: Record<string, { variant: 'success' | 'warning' | 'outline' | 'error'; label: string }> = {
+    connected: { variant: 'success', label: 'Connected' },
+    pending: { variant: 'warning', label: 'Pending' },
+    disconnected: { variant: 'outline', label: 'Disconnected' },
+    error: { variant: 'error', label: 'Error' },
+  };
+
+  const config = variants[status] || variants.disconnected;
+
+  return (
+    <Badge variant={config.variant}>
+      {status === 'pending' && <Loader2 className="size-3 animate-spin mr-1" />}
+      {config.label}
+    </Badge>
+  );
+}
+
+interface HubSpotSettingsCardProps {
+  token?: string;
+  orgId?: string;
+}
+
+export function HubSpotSettingsCard({ token, orgId }: HubSpotSettingsCardProps) {
+  const [modalOpen, setModalOpen] = useState(false);
+  const [isDisconnecting, setIsDisconnecting] = useState(false);
+  const { data: status, isLoading, refetch } = useHubSpotStatus(token, orgId);
+
+  // Create API client with auth context
+  const api = useMemo(() => createApiClient(token, orgId), [token, orgId]);
+
+  const handleDisconnect = async () => {
+    if (!confirm('Are you sure you want to disconnect your HubSpot account? This will stop all automatic syncing.')) {
+      return;
+    }
+
+    if (!status?.integrationId) {
+      alert('Cannot disconnect: Integration ID not found');
+      return;
+    }
+
+    setIsDisconnecting(true);
+    try {
+      const result = await api.delete(`/v1/crm/config/integrations/${status.integrationId}`);
+
+      if (!result.success) {
+        throw new Error(result.error?.message || 'Failed to disconnect');
+      }
+
+      await refetch();
+    } catch (error) {
+      alert(error instanceof Error ? error.message : 'Failed to disconnect HubSpot account');
+    } finally {
+      setIsDisconnecting(false);
+    }
+  };
+
+  const handleSuccess = () => {
+    refetch();
+  };
+
+  if (isLoading) {
+    return (
+      <div className="bg-[var(--navy)] border border-[var(--turquoise)]/20 rounded-lg p-6">
+        {/* Header section skeleton */}
+        <div className="flex items-start justify-between mb-4">
+          <div className="flex items-center gap-3">
+            <Skeleton className="size-10 rounded-lg" />
+            <div className="space-y-2">
+              <Skeleton className="h-5 w-40" />
+              <Skeleton className="h-4 w-56" />
+            </div>
+          </div>
+          <Skeleton className="h-6 w-24 rounded-full" />
+        </div>
+
+        {/* Content section skeleton */}
+        <div className="space-y-4">
+          <div className="bg-[var(--dark-blue)]/50 border border-[var(--turquoise)]/10 rounded-md p-4">
+            <div className="space-y-3">
+              <div className="flex items-center justify-between">
+                <Skeleton className="h-4 w-24" />
+                <Skeleton className="h-4 w-32" />
+              </div>
+              <div className="flex items-center justify-between">
+                <Skeleton className="h-4 w-24" />
+                <Skeleton className="h-4 w-28" />
+              </div>
+            </div>
+          </div>
+
+          <Skeleton className="h-10 w-full rounded-md" />
+        </div>
+      </div>
+    );
+  }
+
+  const isConnected = status?.status === 'connected';
+
+  return (
+    <>
+      <div className="bg-[var(--navy)] border border-[var(--turquoise)]/20 rounded-lg p-6">
+        <div className="flex items-start justify-between mb-4">
+          <div className="flex items-center gap-3">
+            <div className="bg-[var(--dark-blue)] p-2 rounded-lg">
+              <HubSpotIcon className="size-6 text-[#ff7a59]" />
+            </div>
+            <div>
+              <h3 className="text-lg font-semibold text-[var(--cream)]">HubSpot Connection</h3>
+              <p className="text-sm text-[var(--cream)]/60">
+                {isConnected
+                  ? 'Your HubSpot account is connected'
+                  : 'Connect your HubSpot account for CRM sync'}
+              </p>
+            </div>
+          </div>
+          {status?.status && <HubSpotStatusBadge status={status.status} />}
+        </div>
+
+        {isConnected ? (
+          <div className="space-y-4">
+            <div className="bg-[var(--dark-blue)]/50 border border-[var(--turquoise)]/10 rounded-md p-4">
+              <div className="space-y-2">
+                {status?.portalId && (
+                  <div className="flex items-center justify-between">
+                    <span className="text-sm text-[var(--cream)]/60">Portal ID</span>
+                    <span className="text-sm text-[var(--cream)] font-medium font-mono">
+                      {status.portalId}
+                    </span>
+                  </div>
+                )}
+                {status?.lastSyncAt && (
+                  <div className="flex items-center justify-between">
+                    <span className="text-sm text-[var(--cream)]/60">Last Sync</span>
+                    <span className="text-sm text-[var(--cream)]">
+                      {new Date(status.lastSyncAt).toLocaleString()}
+                    </span>
+                  </div>
+                )}
+                {status?.rateLimit && (
+                  <div className="flex items-center justify-between">
+                    <span className="text-sm text-[var(--cream)]/60">API Calls Remaining</span>
+                    <span className="text-sm text-[var(--cream)]">
+                      {status.rateLimit.remaining}/{status.rateLimit.limit}
+                    </span>
+                  </div>
+                )}
+              </div>
+            </div>
+
+            <div className="flex gap-3">
+              <Button
+                variant="outline"
+                onClick={() => window.open('https://app.hubspot.com', '_blank')}
+                className="flex-1"
+              >
+                <ExternalLink className="size-4 mr-2" />
+                Open HubSpot
+              </Button>
+              <Button
+                variant="outline"
+                onClick={handleDisconnect}
+                disabled={isDisconnecting}
+                className="flex-1 border-red-500/50 text-red-400 hover:bg-red-500/10"
+              >
+                {isDisconnecting ? (
+                  <>
+                    <Loader2 className="animate-spin size-4 mr-2" />
+                    Disconnecting...
+                  </>
+                ) : (
+                  'Disconnect'
+                )}
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <EmptyStateHubSpotNotConnected
+            onConnect={() => setModalOpen(true)}
+            className="py-8"
+          />
+        )}
+      </div>
+
+      <ConnectHubSpotModal
+        open={modalOpen}
+        onOpenChange={setModalOpen}
+        onSuccess={handleSuccess}
+        token={token}
+        orgId={orgId}
+      />
+    </>
+  );
+}

--- a/components/settings/LinkedInSettingsCard.tsx
+++ b/components/settings/LinkedInSettingsCard.tsx
@@ -1,0 +1,183 @@
+'use client';
+
+import React, { useState, useMemo } from 'react';
+import { Button } from '@/components/ui/button';
+import { LinkedInStatusBadge } from './LinkedInStatusBadge';
+import { ConnectLinkedInModal } from './ConnectLinkedInModal';
+import { useLinkedInStatus } from '@/lib/hooks/useLinkedInStatus';
+import { Linkedin, ExternalLink, Loader2 } from 'lucide-react';
+import { Skeleton } from '@/components/ui/skeleton';
+import { EmptyStateLinkedInNotConnected } from '@/components/ui/empty-state';
+import { createApiClient } from '@/lib/api-client';
+
+interface LinkedInSettingsCardProps {
+  token?: string;
+  orgId?: string;
+}
+
+export function LinkedInSettingsCard({ token, orgId }: LinkedInSettingsCardProps) {
+  const [modalOpen, setModalOpen] = useState(false);
+  const [isDisconnecting, setIsDisconnecting] = useState(false);
+  const { data: status, isLoading, refetch } = useLinkedInStatus(token, orgId);
+
+  // Create API client with auth context
+  const api = useMemo(() => createApiClient(token, orgId), [token, orgId]);
+
+  const handleDisconnect = async () => {
+    if (!confirm('Are you sure you want to disconnect your LinkedIn account?')) {
+      return;
+    }
+
+    setIsDisconnecting(true);
+    try {
+      const result = await api.delete('/v1/linkedin-connection');
+
+      if (!result.success) {
+        throw new Error(result.error?.message || 'Failed to disconnect');
+      }
+
+      await refetch();
+    } catch (error) {
+      alert(error instanceof Error ? error.message : 'Failed to disconnect LinkedIn account');
+    } finally {
+      setIsDisconnecting(false);
+    }
+  };
+
+  const handleSuccess = () => {
+    refetch();
+  };
+
+  if (isLoading) {
+    return (
+      <div className="bg-[var(--navy)] border border-[var(--turquoise)]/20 rounded-lg p-6">
+        {/* Header section skeleton */}
+        <div className="flex items-start justify-between mb-4">
+          <div className="flex items-center gap-3">
+            <Skeleton className="size-10 rounded-lg" />
+            <div className="space-y-2">
+              <Skeleton className="h-5 w-40" />
+              <Skeleton className="h-4 w-56" />
+            </div>
+          </div>
+          <Skeleton className="h-6 w-24 rounded-full" />
+        </div>
+
+        {/* Content section skeleton */}
+        <div className="space-y-4">
+          <div className="bg-[var(--dark-blue)]/50 border border-[var(--turquoise)]/10 rounded-md p-4">
+            <div className="space-y-3">
+              <div className="flex items-center justify-between">
+                <Skeleton className="h-4 w-24" />
+                <Skeleton className="h-4 w-32" />
+              </div>
+              <div className="flex items-center justify-between">
+                <Skeleton className="h-4 w-24" />
+                <Skeleton className="h-4 w-28" />
+              </div>
+              <div className="flex items-center justify-between">
+                <Skeleton className="h-4 w-24" />
+                <Skeleton className="h-4 w-20" />
+              </div>
+            </div>
+          </div>
+
+          <Skeleton className="h-10 w-full rounded-md" />
+        </div>
+      </div>
+    );
+  }
+
+  const isConnected = status?.status === 'connected';
+
+  return (
+    <>
+      <div className="bg-[var(--navy)] border border-[var(--turquoise)]/20 rounded-lg p-6">
+        <div className="flex items-start justify-between mb-4">
+          <div className="flex items-center gap-3">
+            <div className="bg-[var(--dark-blue)] p-2 rounded-lg">
+              <Linkedin className="size-6 text-[var(--turquoise)]" />
+            </div>
+            <div>
+              <h3 className="text-lg font-semibold text-[var(--cream)]">LinkedIn Connection</h3>
+              <p className="text-sm text-[var(--cream)]/60">
+                {isConnected
+                  ? 'Your LinkedIn account is connected'
+                  : 'Connect your LinkedIn account for data enrichment'}
+              </p>
+            </div>
+          </div>
+          {status?.status && <LinkedInStatusBadge status={status.status} />}
+        </div>
+
+        {isConnected ? (
+          <div className="space-y-4">
+            <div className="bg-[var(--dark-blue)]/50 border border-[var(--turquoise)]/10 rounded-md p-4">
+              <div className="space-y-2">
+                {status?.linkedInProfileName && (
+                  <div className="flex items-center justify-between">
+                    <span className="text-sm text-[var(--cream)]/60">Profile Name</span>
+                    <span className="text-sm text-[var(--cream)] font-medium">
+                      {status.linkedInProfileName}
+                    </span>
+                  </div>
+                )}
+                {status?.linkedInProfileUrl && (
+                  <div className="flex items-center justify-between">
+                    <span className="text-sm text-[var(--cream)]/60">Profile URL</span>
+                    <a
+                      href={status.linkedInProfileUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-sm text-[var(--turquoise)] hover:text-[var(--turquoise)]/80 hover:underline flex items-center gap-1"
+                    >
+                      View Profile
+                      <ExternalLink className="size-3" />
+                    </a>
+                  </div>
+                )}
+                {status?.connectedAt && (
+                  <div className="flex items-center justify-between">
+                    <span className="text-sm text-[var(--cream)]/60">Connected At</span>
+                    <span className="text-sm text-[var(--cream)]">
+                      {new Date(status.connectedAt).toLocaleDateString()}
+                    </span>
+                  </div>
+                )}
+              </div>
+            </div>
+
+            <Button
+              variant="outline"
+              onClick={handleDisconnect}
+              disabled={isDisconnecting}
+              className="w-full border-red-500/50 text-red-400 hover:bg-red-500/10"
+            >
+              {isDisconnecting ? (
+                <>
+                  <Loader2 className="animate-spin size-4 mr-2" />
+                  Disconnecting...
+                </>
+              ) : (
+                'Disconnect LinkedIn'
+              )}
+            </Button>
+          </div>
+        ) : (
+          <EmptyStateLinkedInNotConnected
+            onConnect={() => setModalOpen(true)}
+            className="py-8"
+          />
+        )}
+      </div>
+
+      <ConnectLinkedInModal
+        open={modalOpen}
+        onOpenChange={setModalOpen}
+        onSuccess={handleSuccess}
+        token={token}
+        orgId={orgId}
+      />
+    </>
+  );
+}

--- a/components/settings/LinkedInStatusBadge.tsx
+++ b/components/settings/LinkedInStatusBadge.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import React from 'react';
+import { Badge } from '@/components/ui/badge';
+import { Check, AlertCircle, Loader2 } from 'lucide-react';
+import type { LinkedInStatus } from '@/lib/hooks/useLinkedInStatus';
+
+interface LinkedInStatusBadgeProps {
+  status?: LinkedInStatus['status'];
+}
+
+export function LinkedInStatusBadge({ status }: LinkedInStatusBadgeProps) {
+  const displayStatus = status ?? 'disconnected';
+
+  const badgeConfig = {
+    connected: {
+      variant: 'success' as const,
+      icon: Check,
+      label: 'Connected',
+    },
+    pending: {
+      variant: 'warning' as const,
+      icon: Loader2,
+      label: 'Pending',
+    },
+    disconnected: {
+      variant: 'outline' as const,
+      icon: null,
+      label: 'Disconnected',
+    },
+    error: {
+      variant: 'error' as const,
+      icon: AlertCircle,
+      label: 'Error',
+    },
+  };
+
+  const config = badgeConfig[displayStatus] ?? badgeConfig.disconnected;
+  const Icon = config.icon;
+
+  return (
+    <Badge variant={config.variant}>
+      {Icon && (
+        <Icon
+          className={
+            displayStatus === 'pending'
+              ? 'animate-spin h-3 w-3'
+              : 'h-3 w-3'
+          }
+        />
+      )}
+      {config.label}
+    </Badge>
+  );
+}

--- a/components/settings/index.ts
+++ b/components/settings/index.ts
@@ -1,0 +1,5 @@
+export { LinkedInStatusBadge } from './LinkedInStatusBadge';
+export { ConnectLinkedInModal } from './ConnectLinkedInModal';
+export { LinkedInSettingsCard } from './LinkedInSettingsCard';
+export { ConnectHubSpotModal, HubSpotIcon } from './ConnectHubSpotModal';
+export { HubSpotSettingsCard } from './HubSpotSettingsCard';

--- a/components/ui/empty-state.tsx
+++ b/components/ui/empty-state.tsx
@@ -1,0 +1,309 @@
+/**
+ * Empty State Component System
+ * A collection of empty state components for various scenarios where no data
+ * or content is available.
+ */
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+import {
+  Search,
+  FolderOpen,
+  Key,
+  Linkedin,
+  AlertCircle,
+  Inbox,
+  type LucideIcon,
+} from "lucide-react";
+
+/**
+ * Props for the base EmptyState component.
+ */
+export interface EmptyStateProps {
+  icon?: LucideIcon;
+  title: string;
+  description?: string;
+  action?: React.ReactNode;
+  secondaryAction?: React.ReactNode;
+  className?: string;
+}
+
+/**
+ * EmptyState - Base component for creating custom empty state displays.
+ */
+const EmptyState = React.forwardRef<HTMLDivElement, EmptyStateProps>(
+  (
+    {
+      icon: Icon = Inbox,
+      title,
+      description,
+      action,
+      secondaryAction,
+      className,
+    },
+    ref
+  ) => {
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          "flex flex-col items-center justify-center py-12 px-6 text-center",
+          className
+        )}
+      >
+        <div className="mb-4 rounded-full bg-[var(--turquoise)]/10 p-4">
+          <Icon className="h-8 w-8 text-[var(--turquoise)]" />
+        </div>
+        <h3 className="mb-2 text-lg font-semibold text-[var(--cream)]">
+          {title}
+        </h3>
+        {description && (
+          <p className="mb-6 max-w-sm text-sm text-[var(--cream)]/60">
+            {description}
+          </p>
+        )}
+        {(action || secondaryAction) && (
+          <div className="flex flex-col sm:flex-row gap-3">
+            {action}
+            {secondaryAction}
+          </div>
+        )}
+      </div>
+    );
+  }
+);
+EmptyState.displayName = "EmptyState";
+
+/**
+ * EmptyStateNoResults - for search results with no matches
+ */
+export interface EmptyStateNoResultsProps {
+  searchTerm?: string;
+  onClearSearch?: () => void;
+  className?: string;
+}
+
+const EmptyStateNoResults = React.forwardRef<
+  HTMLDivElement,
+  EmptyStateNoResultsProps
+>(({ searchTerm, onClearSearch, className }, ref) => {
+  return (
+    <EmptyState
+      ref={ref}
+      icon={Search}
+      title="No results found"
+      description={
+        searchTerm
+          ? `We couldn't find any results for "${searchTerm}". Try adjusting your search.`
+          : "We couldn't find any matching results. Try a different search term."
+      }
+      action={
+        onClearSearch && (
+          <button
+            onClick={onClearSearch}
+            className="inline-flex items-center justify-center rounded-md px-4 py-2 text-sm font-medium bg-[var(--turquoise)] text-[var(--dark-blue)] hover:bg-[var(--dark-turquoise)] transition-colors"
+          >
+            Clear search
+          </button>
+        )
+      }
+      className={className}
+    />
+  );
+});
+EmptyStateNoResults.displayName = "EmptyStateNoResults";
+
+/**
+ * EmptyStateNoData - for empty collections/lists
+ */
+export interface EmptyStateNoDataProps {
+  resourceName?: string;
+  onCreateNew?: () => void;
+  className?: string;
+}
+
+const EmptyStateNoData = React.forwardRef<HTMLDivElement, EmptyStateNoDataProps>(
+  ({ resourceName = "items", onCreateNew, className }, ref) => {
+    return (
+      <EmptyState
+        ref={ref}
+        icon={FolderOpen}
+        title={`No ${resourceName} yet`}
+        description={`Get started by creating your first ${resourceName.slice(0, -1) || resourceName}.`}
+        action={
+          onCreateNew && (
+            <button
+              onClick={onCreateNew}
+              className="inline-flex items-center justify-center rounded-md px-4 py-2 text-sm font-medium bg-[var(--turquoise)] text-[var(--dark-blue)] hover:bg-[var(--dark-turquoise)] transition-colors"
+            >
+              Create {resourceName.slice(0, -1) || resourceName}
+            </button>
+          )
+        }
+        className={className}
+      />
+    );
+  }
+);
+EmptyStateNoData.displayName = "EmptyStateNoData";
+
+/**
+ * EmptyStateNoAPIKeys - for API key management
+ */
+export interface EmptyStateNoAPIKeysProps {
+  onCreateKey?: () => void;
+  className?: string;
+}
+
+const EmptyStateNoAPIKeys = React.forwardRef<
+  HTMLDivElement,
+  EmptyStateNoAPIKeysProps
+>(({ onCreateKey, className }, ref) => {
+  return (
+    <EmptyState
+      ref={ref}
+      icon={Key}
+      title="No API keys"
+      description="Create an API key to start integrating with ABM.dev. Your key will give you access to enrichment, content generation, and more."
+      action={
+        onCreateKey && (
+          <button
+            onClick={onCreateKey}
+            className="inline-flex items-center justify-center rounded-md px-4 py-2 text-sm font-medium bg-[var(--turquoise)] text-[var(--dark-blue)] hover:bg-[var(--dark-turquoise)] transition-colors"
+          >
+            <Key className="mr-2 h-4 w-4" />
+            Create API Key
+          </button>
+        )
+      }
+      className={className}
+    />
+  );
+});
+EmptyStateNoAPIKeys.displayName = "EmptyStateNoAPIKeys";
+
+/**
+ * EmptyStateLinkedInNotConnected - for LinkedIn integration status
+ */
+export interface EmptyStateLinkedInNotConnectedProps {
+  onConnect?: () => void;
+  className?: string;
+}
+
+const EmptyStateLinkedInNotConnected = React.forwardRef<
+  HTMLDivElement,
+  EmptyStateLinkedInNotConnectedProps
+>(({ onConnect, className }, ref) => {
+  return (
+    <EmptyState
+      ref={ref}
+      icon={Linkedin}
+      title="LinkedIn not connected"
+      description="Connect your LinkedIn account to enable profile enrichment and Sales Navigator integration."
+      action={
+        onConnect && (
+          <button
+            onClick={onConnect}
+            className="inline-flex items-center justify-center rounded-md px-4 py-2 text-sm font-medium bg-[#0A66C2] text-white hover:bg-[#004182] transition-colors"
+          >
+            <Linkedin className="mr-2 h-4 w-4" />
+            Connect LinkedIn
+          </button>
+        )
+      }
+      className={className}
+    />
+  );
+});
+EmptyStateLinkedInNotConnected.displayName = "EmptyStateLinkedInNotConnected";
+
+// HubSpot icon component
+function HubSpotIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="currentColor">
+      <path d="M18.164 7.93V5.086a2.198 2.198 0 0 0 1.267-1.978V3.06a2.198 2.198 0 0 0-2.198-2.198h-.048a2.198 2.198 0 0 0-2.198 2.198v.048a2.198 2.198 0 0 0 1.267 1.978V7.93a5.996 5.996 0 0 0-2.77 1.29L6.164 3.71a2.43 2.43 0 1 0-1.358 1.13l7.26 5.418a6.002 6.002 0 0 0 .084 6.53l-2.18 2.18a1.835 1.835 0 1 0 1.13 1.13l2.18-2.18a6.002 6.002 0 0 0 6.53.084 6.002 6.002 0 0 0-1.646-10.072Zm-.979 8.059a3.453 3.453 0 1 1 0-6.905 3.453 3.453 0 0 1 0 6.905Z"/>
+    </svg>
+  );
+}
+
+/**
+ * EmptyStateHubSpotNotConnected - for HubSpot CRM integration status
+ */
+export interface EmptyStateHubSpotNotConnectedProps {
+  onConnect?: () => void;
+  className?: string;
+}
+
+const EmptyStateHubSpotNotConnected = React.forwardRef<
+  HTMLDivElement,
+  EmptyStateHubSpotNotConnectedProps
+>(({ onConnect, className }, ref) => {
+  return (
+    <EmptyState
+      ref={ref}
+      icon={Inbox}
+      title="HubSpot not connected"
+      description="Connect your HubSpot account to automatically sync enriched contacts and companies to your CRM."
+      action={
+        onConnect && (
+          <button
+            onClick={onConnect}
+            className="inline-flex items-center justify-center rounded-md px-4 py-2 text-sm font-medium bg-[#ff7a59] text-white hover:bg-[#e86a4a] transition-colors"
+          >
+            <HubSpotIcon className="mr-2 h-4 w-4" />
+            Connect HubSpot
+          </button>
+        )
+      }
+      className={className}
+    />
+  );
+});
+EmptyStateHubSpotNotConnected.displayName = "EmptyStateHubSpotNotConnected";
+
+/**
+ * EmptyStateError - for error states
+ */
+export interface EmptyStateErrorProps {
+  message?: string;
+  onRetry?: () => void;
+  className?: string;
+}
+
+const EmptyStateError = React.forwardRef<HTMLDivElement, EmptyStateErrorProps>(
+  ({ message, onRetry, className }, ref) => {
+    return (
+      <EmptyState
+        ref={ref}
+        icon={AlertCircle}
+        title="Something went wrong"
+        description={
+          message || "An error occurred while loading the data. Please try again."
+        }
+        action={
+          onRetry && (
+            <button
+              onClick={onRetry}
+              className="inline-flex items-center justify-center rounded-md px-4 py-2 text-sm font-medium bg-[var(--turquoise)] text-[var(--dark-blue)] hover:bg-[var(--dark-turquoise)] transition-colors"
+            >
+              Try again
+            </button>
+          )
+        }
+        className={className}
+      />
+    );
+  }
+);
+EmptyStateError.displayName = "EmptyStateError";
+
+export {
+  EmptyState,
+  EmptyStateNoResults,
+  EmptyStateNoData,
+  EmptyStateNoAPIKeys,
+  EmptyStateLinkedInNotConnected,
+  EmptyStateHubSpotNotConnected,
+  EmptyStateError,
+  HubSpotIcon,
+};

--- a/components/ui/skeleton.tsx
+++ b/components/ui/skeleton.tsx
@@ -1,0 +1,209 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+/**
+ * Skeleton Loading Components
+ * A suite of skeleton loading components for creating placeholder UI while content is being fetched.
+ */
+
+// Base Skeleton component
+export interface SkeletonProps extends React.HTMLAttributes<HTMLDivElement> {
+  className?: string;
+}
+
+const Skeleton = React.forwardRef<HTMLDivElement, SkeletonProps>(
+  ({ className, ...props }, ref) => {
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          "animate-pulse rounded-md bg-[var(--turquoise)]/10",
+          className
+        )}
+        {...props}
+      />
+    );
+  }
+);
+Skeleton.displayName = "Skeleton";
+
+/**
+ * SkeletonText - for text content placeholders
+ */
+export interface SkeletonTextProps {
+  lines?: number;
+  className?: string;
+  lastLineWidth?: "full" | "3/4" | "1/2" | "1/4";
+}
+
+const SkeletonText = React.forwardRef<HTMLDivElement, SkeletonTextProps>(
+  ({ lines = 3, className, lastLineWidth = "3/4" }, ref) => {
+    const lastWidthClass = {
+      full: "w-full",
+      "3/4": "w-3/4",
+      "1/2": "w-1/2",
+      "1/4": "w-1/4",
+    };
+
+    return (
+      <div ref={ref} className={cn("space-y-2", className)}>
+        {Array.from({ length: lines }).map((_, i) => (
+          <Skeleton
+            key={i}
+            className={cn(
+              "h-4",
+              i === lines - 1 ? lastWidthClass[lastLineWidth] : "w-full"
+            )}
+          />
+        ))}
+      </div>
+    );
+  }
+);
+SkeletonText.displayName = "SkeletonText";
+
+/**
+ * SkeletonCard - for card content placeholders
+ */
+export interface SkeletonCardProps {
+  hasHeader?: boolean;
+  hasFooter?: boolean;
+  className?: string;
+}
+
+const SkeletonCard = React.forwardRef<HTMLDivElement, SkeletonCardProps>(
+  ({ hasHeader = true, hasFooter = false, className }, ref) => {
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          "rounded-lg border border-[var(--turquoise)]/20 bg-[var(--navy)] p-6",
+          className
+        )}
+      >
+        {hasHeader && (
+          <div className="mb-4 flex items-center gap-3">
+            <Skeleton className="h-10 w-10 rounded-full" />
+            <div className="flex-1 space-y-2">
+              <Skeleton className="h-4 w-1/3" />
+              <Skeleton className="h-3 w-1/4" />
+            </div>
+          </div>
+        )}
+        <div className="space-y-3">
+          <Skeleton className="h-4 w-full" />
+          <Skeleton className="h-4 w-full" />
+          <Skeleton className="h-4 w-3/4" />
+        </div>
+        {hasFooter && (
+          <div className="mt-4 flex gap-2">
+            <Skeleton className="h-9 w-24 rounded-md" />
+            <Skeleton className="h-9 w-24 rounded-md" />
+          </div>
+        )}
+      </div>
+    );
+  }
+);
+SkeletonCard.displayName = "SkeletonCard";
+
+/**
+ * SkeletonList - for list item placeholders
+ */
+export interface SkeletonListProps {
+  count?: number;
+  hasAvatar?: boolean;
+  className?: string;
+}
+
+const SkeletonList = React.forwardRef<HTMLDivElement, SkeletonListProps>(
+  ({ count = 5, hasAvatar = false, className }, ref) => {
+    return (
+      <div ref={ref} className={cn("space-y-4", className)}>
+        {Array.from({ length: count }).map((_, i) => (
+          <div key={i} className="flex items-center gap-4">
+            {hasAvatar && <Skeleton className="h-10 w-10 rounded-full flex-shrink-0" />}
+            <div className="flex-1 space-y-2">
+              <Skeleton className="h-4 w-2/3" />
+              <Skeleton className="h-3 w-1/2" />
+            </div>
+          </div>
+        ))}
+      </div>
+    );
+  }
+);
+SkeletonList.displayName = "SkeletonList";
+
+/**
+ * SkeletonAvatar - for avatar/profile picture placeholders
+ */
+export interface SkeletonAvatarProps {
+  size?: "sm" | "default" | "lg" | "xl";
+  className?: string;
+}
+
+const SkeletonAvatar = React.forwardRef<HTMLDivElement, SkeletonAvatarProps>(
+  ({ size = "default", className }, ref) => {
+    const sizeClasses = {
+      sm: "h-8 w-8",
+      default: "h-10 w-10",
+      lg: "h-12 w-12",
+      xl: "h-16 w-16",
+    };
+
+    return (
+      <Skeleton
+        ref={ref}
+        className={cn("rounded-full", sizeClasses[size], className)}
+      />
+    );
+  }
+);
+SkeletonAvatar.displayName = "SkeletonAvatar";
+
+/**
+ * SkeletonButton - for button placeholders
+ */
+export interface SkeletonButtonProps {
+  size?: "sm" | "default" | "lg";
+  width?: "auto" | "full";
+  className?: string;
+}
+
+const SkeletonButton = React.forwardRef<HTMLDivElement, SkeletonButtonProps>(
+  ({ size = "default", width = "auto", className }, ref) => {
+    const sizeClasses = {
+      sm: "h-8",
+      default: "h-10",
+      lg: "h-12",
+    };
+
+    const widthClasses = {
+      auto: "w-24",
+      full: "w-full",
+    };
+
+    return (
+      <Skeleton
+        ref={ref}
+        className={cn(
+          "rounded-md",
+          sizeClasses[size],
+          widthClasses[width],
+          className
+        )}
+      />
+    );
+  }
+);
+SkeletonButton.displayName = "SkeletonButton";
+
+export {
+  Skeleton,
+  SkeletonText,
+  SkeletonCard,
+  SkeletonList,
+  SkeletonAvatar,
+  SkeletonButton,
+};

--- a/lib/hooks/useHubSpotStatus.ts
+++ b/lib/hooks/useHubSpotStatus.ts
@@ -1,0 +1,108 @@
+import { useState, useEffect, useCallback, useMemo } from 'react';
+import { createApiClient } from '../api-client';
+
+export interface HubSpotStatus {
+  status: 'connected' | 'pending' | 'disconnected' | 'error';
+  integrationId?: string;
+  portalId?: string;
+  lastSyncAt?: string;
+  lastTestedAt?: string;
+  testStatus?: 'success' | 'failed' | 'pending';
+  rateLimit?: {
+    remaining: number;
+    limit: number;
+    resetsAt?: string;
+  };
+}
+
+interface HealthResponse {
+  connected?: boolean;
+  is_connected?: boolean;
+  integration_id?: string;
+  portal_id?: string;
+  last_sync?: string;
+  last_tested_at?: string;
+  test_status?: string;
+  rate_limit?: {
+    remaining: number;
+    limit: number;
+    resets_at?: string;
+  };
+}
+
+/**
+ * Custom hook for HubSpot connection status
+ * SSR-safe - doesn't use react-query to avoid QueryClientProvider requirement during SSR
+ */
+export function useHubSpotStatus(token?: string, orgId?: string) {
+  const [data, setData] = useState<HubSpotStatus | undefined>(undefined);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  // Create API client with auth context
+  const api = useMemo(() => createApiClient(token, orgId), [token, orgId]);
+
+  const fetchStatus = useCallback(async () => {
+    if (!token || typeof window === 'undefined') {
+      setIsLoading(false);
+      return;
+    }
+
+    try {
+      setIsLoading(true);
+      const result = await api.get<HealthResponse>('/v1/crm/config/platforms/hubspot/health');
+
+      if (result.success && result.data) {
+        const response = result.data;
+        // Map API response to our interface
+        setData({
+          status: (response.connected || response.is_connected) ? 'connected' : 'disconnected',
+          integrationId: response.integration_id,
+          portalId: response.portal_id,
+          lastSyncAt: response.last_sync,
+          lastTestedAt: response.last_tested_at,
+          testStatus: response.test_status as HubSpotStatus['testStatus'],
+          rateLimit: response.rate_limit ? {
+            remaining: response.rate_limit.remaining,
+            limit: response.rate_limit.limit,
+            resetsAt: response.rate_limit.resets_at,
+          } : undefined,
+        });
+        setError(null);
+      } else {
+        // Handle disconnected state from backend error
+        if (result.error?.details && typeof result.error.details === 'object') {
+          const details = result.error.details as { configured?: boolean };
+          if (details.configured === false) {
+            setData({ status: 'disconnected' });
+            setError(null);
+            return;
+          }
+        }
+        throw new Error(result.error?.message || 'Failed to fetch status');
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error('Unknown error'));
+      setData({ status: 'disconnected' });
+    } finally {
+      setIsLoading(false);
+    }
+  }, [token, api]);
+
+  // Initial fetch
+  useEffect(() => {
+    fetchStatus();
+  }, [fetchStatus]);
+
+  // Poll when status is pending
+  useEffect(() => {
+    if (data?.status === 'pending') {
+      const interval = setInterval(fetchStatus, 5000);
+      return () => clearInterval(interval);
+    }
+  }, [data?.status, fetchStatus]);
+
+  const refetch = useCallback(() => fetchStatus(), [fetchStatus]);
+
+  return { data, isLoading, error, refetch };
+}

--- a/lib/hooks/useLinkedInStatus.ts
+++ b/lib/hooks/useLinkedInStatus.ts
@@ -1,0 +1,73 @@
+import { useState, useEffect, useCallback, useMemo } from 'react';
+import { createApiClient } from '../api-client';
+
+export interface LinkedInStatus {
+  status: 'connected' | 'pending' | 'disconnected' | 'error';
+  linkedInProfileName?: string;
+  linkedInProfileUrl?: string;
+  connectedAt?: string;
+  lastVerifiedAt?: string;
+  message?: string;
+}
+
+/**
+ * Custom hook for LinkedIn connection status
+ * SSR-safe - doesn't use react-query to avoid QueryClientProvider requirement during SSR
+ */
+export function useLinkedInStatus(token?: string, orgId?: string) {
+  const [data, setData] = useState<LinkedInStatus | undefined>(undefined);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  // Create API client with auth context
+  const api = useMemo(() => createApiClient(token, orgId), [token, orgId]);
+
+  const fetchStatus = useCallback(async () => {
+    if (!token || typeof window === 'undefined') {
+      setIsLoading(false);
+      return;
+    }
+
+    try {
+      setIsLoading(true);
+      const result = await api.get<LinkedInStatus>('/v1/linkedin-connection/status');
+
+      if (result.success && result.data) {
+        setData(result.data);
+        setError(null);
+      } else {
+        // Handle disconnected state from backend error
+        if (result.error?.details && typeof result.error.details === 'object') {
+          const details = result.error.details as { configured?: boolean };
+          if (details.configured === false) {
+            setData({ status: 'disconnected' });
+            setError(null);
+            return;
+          }
+        }
+        throw new Error(result.error?.message || 'Failed to fetch status');
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error('Unknown error'));
+    } finally {
+      setIsLoading(false);
+    }
+  }, [token, api]);
+
+  // Initial fetch
+  useEffect(() => {
+    fetchStatus();
+  }, [fetchStatus]);
+
+  // Poll when status is pending
+  useEffect(() => {
+    if (data?.status === 'pending') {
+      const interval = setInterval(fetchStatus, 5000);
+      return () => clearInterval(interval);
+    }
+  }, [data?.status, fetchStatus]);
+
+  const refetch = useCallback(() => fetchStatus(), [fetchStatus]);
+
+  return { data, isLoading, error, refetch };
+}


### PR DESCRIPTION
## Summary
Port integration components from turquoise-koala that connect to the abm.dev-platform backend via the API gateway.

### LinkedIn Integration (#43)
- API client library for backend communication with auth headers
- `useLinkedInStatus` hook with auto-polling when status is 'pending'
- Connection flow: Initialize → Open Browserbase popup → User logs in → Verify → Connected
- Components: `LinkedInStatusBadge`, `ConnectLinkedInModal`, `LinkedInSettingsCard`

### HubSpot Integration (#44)
- `useHubSpotStatus` hook for health checking
- Private App token validation (pat-xxx format)
- Components: `ConnectHubSpotModal`, `HubSpotSettingsCard`

### Shared Components
- `Skeleton` loading components for better UX
- `EmptyState` components for disconnected states

## Related Issues
Closes #43
Closes #44

## API Endpoints Used

**LinkedIn:**
- `GET /v1/linkedin-connection/status`
- `POST /v1/linkedin-connection/initialize`
- `POST /v1/linkedin-connection/verify`
- `DELETE /v1/linkedin-connection`

**HubSpot:**
- `GET /v1/crm/config/platforms/hubspot/health`
- `POST /v1/crm/config/integrations`
- `DELETE /v1/crm/config/integrations/{integrationId}`

## Test Plan
- [ ] LinkedIn: Initialize connection flow works (calls API, gets sessionUrl)
- [ ] LinkedIn: Browserbase popup opens correctly
- [ ] LinkedIn: Verify completes and status updates to connected
- [ ] LinkedIn: Profile name/URL displays when connected
- [ ] LinkedIn: Disconnect works
- [ ] HubSpot: Connect modal validates token format (pat-xxx)
- [ ] HubSpot: Connection with valid token succeeds
- [ ] HubSpot: Portal ID and rate limit info displays
- [ ] HubSpot: Disconnect works
- [ ] Error states display correctly for both
- [ ] Loading skeletons appear during fetch

## Environment Setup
Requires `NEXT_PUBLIC_API_GATEWAY_URL` in `.env.local`:
```
NEXT_PUBLIC_API_GATEWAY_URL=https://turquoise-koala-main-cae84bb.zuplo.app
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)