### PR TITLE
feat(portal): Complete 10-sprint portal overhaul

### DIFF
--- a/app/(protected)/api-keys/loading.tsx
+++ b/app/(protected)/api-keys/loading.tsx
@@ -1,0 +1,49 @@
+import { Skeleton } from '@/components/ui/skeleton';
+
+export default function ApiKeysLoading() {
+  return (
+    <div className="space-y-8">
+      {/* Header Skeleton */}
+      <div className="flex items-start justify-between">
+        <div className="space-y-2">
+          <Skeleton className="h-9 w-32" />
+          <Skeleton className="h-5 w-72" />
+        </div>
+        <Skeleton className="h-10 w-36 rounded-md" />
+      </div>
+
+      {/* Table Skeleton */}
+      <div className="rounded-lg border border-[var(--turquoise)]/20 overflow-hidden">
+        {/* Table Header */}
+        <div className="bg-[var(--dark-blue)]/50 border-b border-[var(--turquoise)]/20 p-4">
+          <div className="grid grid-cols-5 gap-4">
+            <Skeleton className="h-4 w-16" />
+            <Skeleton className="h-4 w-16" />
+            <Skeleton className="h-4 w-16" />
+            <Skeleton className="h-4 w-20" />
+            <Skeleton className="h-4 w-16" />
+          </div>
+        </div>
+
+        {/* Table Rows */}
+        {Array.from({ length: 5 }).map((_, i) => (
+          <div
+            key={i}
+            className="border-b border-[var(--turquoise)]/10 last:border-0 p-4"
+          >
+            <div className="grid grid-cols-5 gap-4 items-center">
+              <Skeleton className="h-4 w-32" />
+              <Skeleton className="h-4 w-24 font-mono" />
+              <Skeleton className="h-6 w-16 rounded-full" />
+              <Skeleton className="h-4 w-24" />
+              <div className="flex gap-2 justify-end">
+                <Skeleton className="h-8 w-8 rounded-md" />
+                <Skeleton className="h-8 w-8 rounded-md" />
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/(protected)/dashboard/loading.tsx
+++ b/app/(protected)/dashboard/loading.tsx
@@ -1,0 +1,96 @@
+import { Skeleton } from '@/components/ui/skeleton';
+
+export default function DashboardLoading() {
+  return (
+    <div className="space-y-8">
+      {/* Header Skeleton */}
+      <div className="space-y-2">
+        <Skeleton className="h-9 w-64" />
+        <Skeleton className="h-5 w-96" />
+      </div>
+
+      {/* Stats Grid Skeleton */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div
+            key={i}
+            className="p-6 rounded-lg bg-[var(--navy)] border border-[var(--turquoise)]/20"
+          >
+            <div className="flex items-start justify-between">
+              <div className="space-y-2">
+                <Skeleton className="h-4 w-24" />
+                <Skeleton className="h-8 w-16" />
+                <Skeleton className="h-3 w-20" />
+              </div>
+              <Skeleton className="h-12 w-12 rounded-lg" />
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Usage & Integrations Row Skeleton */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        {/* Usage Section Skeleton */}
+        <div className="p-6 rounded-lg bg-[var(--navy)] border border-[var(--turquoise)]/20 space-y-6">
+          <Skeleton className="h-6 w-40" />
+          <div className="space-y-2">
+            <div className="flex justify-between">
+              <Skeleton className="h-4 w-20" />
+              <Skeleton className="h-4 w-24" />
+            </div>
+            <Skeleton className="h-2 w-full rounded-full" />
+          </div>
+          <div className="space-y-2">
+            <div className="flex justify-between">
+              <Skeleton className="h-4 w-24" />
+              <Skeleton className="h-4 w-24" />
+            </div>
+            <Skeleton className="h-2 w-full rounded-full" />
+          </div>
+        </div>
+
+        {/* Integrations Skeleton */}
+        <div className="p-6 rounded-lg bg-[var(--navy)] border border-[var(--turquoise)]/20">
+          <div className="flex items-center justify-between mb-4">
+            <Skeleton className="h-6 w-32" />
+            <Skeleton className="h-4 w-24" />
+          </div>
+          <div className="space-y-3">
+            {Array.from({ length: 3 }).map((_, i) => (
+              <div key={i} className="flex items-center justify-between p-3 rounded-lg bg-[var(--turquoise)]/5 border border-[var(--turquoise)]/10">
+                <div className="flex items-center gap-3">
+                  <Skeleton className="h-8 w-8 rounded-lg" />
+                  <Skeleton className="h-4 w-20" />
+                </div>
+                <Skeleton className="h-4 w-4" />
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* Activity Skeleton */}
+      <div className="p-6 rounded-lg bg-[var(--navy)] border border-[var(--turquoise)]/20">
+        <Skeleton className="h-6 w-36 mb-4" />
+        <Skeleton className="h-4 w-48 mx-auto" />
+      </div>
+
+      {/* Quick Actions Skeleton */}
+      <div className="space-y-4">
+        <Skeleton className="h-7 w-36" />
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div
+              key={i}
+              className="p-5 rounded-lg bg-[var(--navy)] border border-[var(--turquoise)]/20"
+            >
+              <Skeleton className="h-10 w-10 rounded-lg mb-3" />
+              <Skeleton className="h-5 w-24 mb-1" />
+              <Skeleton className="h-3 w-32" />
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/(protected)/layout.tsx
+++ b/app/(protected)/layout.tsx
@@ -16,7 +16,7 @@ export default async function ProtectedLayout({
   return (
     <div className="min-h-screen bg-[var(--dark-blue)]">
       <Navigation />
-      <main className="container mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      <main id="main-content" className="container mx-auto px-4 sm:px-6 lg:px-8 py-8">
         {children}
       </main>
     </div>

--- a/app/(protected)/settings/account/page.tsx
+++ b/app/(protected)/settings/account/page.tsx
@@ -2,6 +2,7 @@ import { currentUser } from '@clerk/nextjs/server'
 import { UserButton } from '@clerk/nextjs'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
+import { DeleteAccountButton } from '@/components/settings/DeleteAccountButton'
 import { Mail, Calendar, Shield, ExternalLink } from 'lucide-react'
 
 export default async function AccountSettingsPage() {
@@ -142,13 +143,7 @@ export default async function AccountSettingsPage() {
               Permanently delete your account and all associated data. This action cannot be undone.
             </p>
           </div>
-          <Button
-            variant="outline"
-            size="sm"
-            className="border-red-500/50 text-red-400 hover:bg-red-500/10 hover:border-red-500"
-          >
-            Delete Account
-          </Button>
+          <DeleteAccountButton />
         </div>
       </div>
     </div>

--- a/app/(protected)/settings/billing/page.tsx
+++ b/app/(protected)/settings/billing/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState } from 'react'
+import { toast } from 'sonner'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import {
@@ -90,7 +91,9 @@ export default function BillingSettingsPage() {
     setIsLoading(true)
     // In production, this would redirect to Stripe Checkout
     await new Promise((resolve) => setTimeout(resolve, 1000))
-    alert(`Upgrade to ${planId} - Stripe Checkout would open here`)
+    toast.info(`Stripe Checkout would open for ${planId.charAt(0).toUpperCase() + planId.slice(1)} plan`, {
+      description: 'Billing integration coming soon'
+    })
     setIsLoading(false)
   }
 

--- a/app/(protected)/settings/loading.tsx
+++ b/app/(protected)/settings/loading.tsx
@@ -1,0 +1,75 @@
+import { Skeleton } from '@/components/ui/skeleton';
+
+export default function SettingsLoading() {
+  return (
+    <div className="space-y-8">
+      {/* Header Skeleton */}
+      <div className="space-y-2">
+        <Skeleton className="h-9 w-32" />
+        <Skeleton className="h-5 w-80" />
+      </div>
+
+      {/* Data Enrichment Section */}
+      <div className="space-y-4">
+        <Skeleton className="h-6 w-36" />
+        <div className="p-4 rounded-lg bg-[var(--navy)] border border-[var(--turquoise)]/20">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-4">
+              <Skeleton className="h-10 w-10 rounded-lg" />
+              <div className="space-y-2">
+                <Skeleton className="h-5 w-24" />
+                <Skeleton className="h-4 w-64" />
+              </div>
+            </div>
+            <Skeleton className="h-5 w-5" />
+          </div>
+        </div>
+      </div>
+
+      {/* CRM Integrations Section */}
+      <div className="space-y-4">
+        <Skeleton className="h-6 w-40" />
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div
+              key={i}
+              className="p-4 rounded-lg bg-[var(--navy)] border border-[var(--turquoise)]/20"
+            >
+              <div className="flex items-start gap-3">
+                <Skeleton className="h-9 w-9 rounded-lg flex-shrink-0" />
+                <div className="space-y-2 flex-1">
+                  <Skeleton className="h-5 w-24" />
+                  <Skeleton className="h-3 w-full" />
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Account Section */}
+      <div className="space-y-4">
+        <Skeleton className="h-6 w-24" />
+        <div className="grid gap-3">
+          {Array.from({ length: 2 }).map((_, i) => (
+            <div
+              key={i}
+              className="p-4 rounded-lg bg-[var(--navy)] border border-[var(--turquoise)]/20"
+            >
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-4">
+                  <Skeleton className="h-10 w-10 rounded-lg" />
+                  <div className="space-y-2">
+                    <Skeleton className="h-5 w-40" />
+                    <Skeleton className="h-4 w-64" />
+                  </div>
+                </div>
+                <Skeleton className="h-5 w-5" />
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/(protected)/settings/page.tsx
+++ b/app/(protected)/settings/page.tsx
@@ -1,43 +1,89 @@
 import Link from 'next/link'
 import { auth } from '@clerk/nextjs/server'
 import { Badge } from '@/components/ui/badge'
-import { Linkedin, Database, CreditCard, User, ArrowRight } from 'lucide-react'
+import { Linkedin, CreditCard, User, ArrowRight, ChevronRight } from 'lucide-react'
+
+// HubSpot icon component
+function HubSpotIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="currentColor">
+      <path d="M18.164 7.93V5.084a2.198 2.198 0 001.267-1.984v-.066a2.198 2.198 0 00-4.396 0V3.1c0 .9.54 1.67 1.313 2.012v2.789a5.42 5.42 0 00-2.477 1.277l-6.44-5.019a2.385 2.385 0 00.092-.642v-.065a2.385 2.385 0 10-2.556 2.376 2.375 2.375 0 001.045-.239l6.317 4.923a5.454 5.454 0 00-.77 2.796 5.464 5.464 0 00.787 2.843l-1.907 1.907a1.81 1.81 0 00-.527-.082 1.834 1.834 0 101.833 1.833c0-.184-.029-.36-.08-.527l1.89-1.89a5.456 5.456 0 108.009-8.463 5.426 5.426 0 00-3.4-1.092zm-.117 8.442a2.85 2.85 0 110-5.702 2.85 2.85 0 010 5.702z" />
+    </svg>
+  )
+}
+
+// Salesforce icon component
+function SalesforceIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="currentColor">
+      <path d="M9.98 6.182a4.27 4.27 0 013.38-1.655 4.277 4.277 0 013.967 2.674 3.643 3.643 0 011.404-.28 3.675 3.675 0 013.678 3.678 3.643 3.643 0 01-.285 1.416 3.196 3.196 0 011.877 2.914 3.203 3.203 0 01-3.203 3.203 3.203 3.203 0 01-.54-.046 3.95 3.95 0 01-3.487 2.089 3.947 3.947 0 01-1.772-.418 4.494 4.494 0 01-7.83-1.573 3.315 3.315 0 01-.616.058 3.34 3.34 0 01-3.34-3.34 3.34 3.34 0 012.035-3.074 4.072 4.072 0 01-.19-1.234 4.094 4.094 0 014.094-4.094 4.072 4.072 0 01.828.085z" />
+    </svg>
+  )
+}
+
+// Dynamics icon component
+function DynamicsIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="currentColor">
+      <path d="M19.5 4.5v6.75l-7.5 4.5-7.5-4.5V4.5L12 9l7.5-4.5zM12 11.25l7.5-4.5V15l-7.5 4.5L4.5 15V6.75l7.5 4.5z" />
+    </svg>
+  )
+}
 
 export default async function SettingsPage() {
   const { userId } = await auth()
 
-  const settingsLinks = [
+  // Data enrichment integrations
+  const enrichmentIntegrations = [
     {
       href: '/settings/linkedin',
       icon: Linkedin,
-      title: 'LinkedIn Integration',
-      description: 'Connect your LinkedIn account for profile enrichment',
-      status: 'Not Connected',
-      statusVariant: 'warning' as const,
+      iconColor: 'text-[#0A66C2]',
+      title: 'LinkedIn',
+      description: 'Connect your LinkedIn account for enhanced profile enrichment',
     },
+  ]
+
+  // CRM integrations
+  const crmIntegrations = [
     {
       href: '/settings/hubspot',
-      icon: Database,
-      title: 'HubSpot Integration',
-      description: 'Connect HubSpot for CRM data synchronization',
-      status: 'Not Connected',
-      statusVariant: 'warning' as const,
+      icon: HubSpotIcon,
+      iconColor: 'text-[#ff7a59]',
+      title: 'HubSpot',
+      description: 'Sync enriched contacts with HubSpot CRM',
     },
+    {
+      href: '/settings/salesforce',
+      icon: SalesforceIcon,
+      iconColor: 'text-[#00a1e0]',
+      title: 'Salesforce',
+      description: 'Sync enriched contacts with Salesforce CRM',
+    },
+    {
+      href: '/settings/dynamics',
+      icon: DynamicsIcon,
+      iconColor: 'text-[#002050]',
+      title: 'Dynamics 365',
+      description: 'Sync enriched contacts with Microsoft Dynamics',
+    },
+  ]
+
+  // Account settings
+  const accountSettings = [
     {
       href: '/settings/billing',
       icon: CreditCard,
+      iconColor: 'text-[var(--turquoise)]',
       title: 'Billing & Subscription',
-      description: 'Manage your subscription and payment methods',
-      status: 'Free Tier',
-      statusVariant: 'secondary' as const,
+      description: 'Manage your subscription plan and payment methods',
     },
     {
       href: '/settings/account',
       icon: User,
+      iconColor: 'text-[var(--turquoise)]',
       title: 'Account Settings',
-      description: 'Update your profile and preferences',
-      status: null,
-      statusVariant: null,
+      description: 'Update your profile and security preferences',
     },
   ]
 
@@ -56,31 +102,79 @@ export default async function SettingsPage() {
         </p>
       </div>
 
-      {/* Settings Links */}
-      <div className="grid gap-4">
-        {settingsLinks.map((link) => (
-          <Link key={link.href} href={link.href} className="block">
-            <div className="p-6 rounded-lg bg-[var(--navy)] border border-[var(--turquoise)]/20 hover:border-[var(--turquoise)]/40 transition-colors group">
-              <div className="flex items-center justify-between">
-                <div className="flex items-center gap-4">
-                  <div className="p-3 rounded-lg bg-[var(--turquoise)]/10">
-                    <link.icon className="w-6 h-6 text-[var(--turquoise)]" />
-                  </div>
-                  <div>
-                    <div className="flex items-center gap-3">
-                      <h3 className="text-[var(--cream)] font-medium">{link.title}</h3>
-                      {link.status && link.statusVariant && (
-                        <Badge variant={link.statusVariant}>{link.status}</Badge>
-                      )}
+      {/* Data Enrichment Section */}
+      <div className="space-y-4">
+        <h2 className="text-lg font-medium text-[var(--cream)]">Data Enrichment</h2>
+        <div className="grid gap-3">
+          {enrichmentIntegrations.map((link) => (
+            <Link key={link.href} href={link.href} className="block group">
+              <div className="p-4 rounded-lg bg-[var(--navy)] border border-[var(--turquoise)]/20 hover:border-[var(--turquoise)]/40 hover:bg-[var(--turquoise)]/5 transition-all">
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-4">
+                    <div className="p-2.5 rounded-lg bg-[var(--dark-blue)]">
+                      <link.icon className={`w-5 h-5 ${link.iconColor}`} />
                     </div>
-                    <p className="text-sm text-[var(--cream)]/60">{link.description}</p>
+                    <div>
+                      <h3 className="text-[var(--cream)] font-medium">{link.title}</h3>
+                      <p className="text-sm text-[var(--cream)]/60">{link.description}</p>
+                    </div>
+                  </div>
+                  <ChevronRight className="w-5 h-5 text-[var(--cream)]/40 group-hover:text-[var(--turquoise)] group-hover:translate-x-0.5 transition-all" />
+                </div>
+              </div>
+            </Link>
+          ))}
+        </div>
+      </div>
+
+      {/* CRM Integrations Section */}
+      <div className="space-y-4">
+        <h2 className="text-lg font-medium text-[var(--cream)]">CRM Integrations</h2>
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {crmIntegrations.map((link) => (
+            <Link key={link.href} href={link.href} className="block group">
+              <div className="p-4 rounded-lg bg-[var(--navy)] border border-[var(--turquoise)]/20 hover:border-[var(--turquoise)]/40 hover:bg-[var(--turquoise)]/5 transition-all h-full">
+                <div className="flex items-start gap-3">
+                  <div className="p-2 rounded-lg bg-[var(--dark-blue)] flex-shrink-0">
+                    <link.icon className={`w-5 h-5 ${link.iconColor}`} />
+                  </div>
+                  <div className="min-w-0">
+                    <h3 className="text-[var(--cream)] font-medium flex items-center gap-2">
+                      {link.title}
+                      <ChevronRight className="w-4 h-4 text-[var(--cream)]/40 group-hover:text-[var(--turquoise)] group-hover:translate-x-0.5 transition-all" />
+                    </h3>
+                    <p className="text-xs text-[var(--cream)]/60 mt-1">{link.description}</p>
                   </div>
                 </div>
-                <ArrowRight className="w-5 h-5 text-[var(--cream)]/40 group-hover:text-[var(--turquoise)] transition-colors" />
               </div>
-            </div>
-          </Link>
-        ))}
+            </Link>
+          ))}
+        </div>
+      </div>
+
+      {/* Account Settings Section */}
+      <div className="space-y-4">
+        <h2 className="text-lg font-medium text-[var(--cream)]">Account</h2>
+        <div className="grid gap-3">
+          {accountSettings.map((link) => (
+            <Link key={link.href} href={link.href} className="block group">
+              <div className="p-4 rounded-lg bg-[var(--navy)] border border-[var(--turquoise)]/20 hover:border-[var(--turquoise)]/40 hover:bg-[var(--turquoise)]/5 transition-all">
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-4">
+                    <div className="p-2.5 rounded-lg bg-[var(--turquoise)]/10">
+                      <link.icon className={`w-5 h-5 ${link.iconColor}`} />
+                    </div>
+                    <div>
+                      <h3 className="text-[var(--cream)] font-medium">{link.title}</h3>
+                      <p className="text-sm text-[var(--cream)]/60">{link.description}</p>
+                    </div>
+                  </div>
+                  <ChevronRight className="w-5 h-5 text-[var(--cream)]/40 group-hover:text-[var(--turquoise)] group-hover:translate-x-0.5 transition-all" />
+                </div>
+              </div>
+            </Link>
+          ))}
+        </div>
       </div>
     </div>
   )

--- a/app/api-reference/configuration/page.tsx
+++ b/app/api-reference/configuration/page.tsx
@@ -1,0 +1,239 @@
+import { EndpointCard } from "@/components/api-reference";
+import { Settings } from "lucide-react";
+
+export const metadata = {
+  title: "Configuration API - ABM.dev",
+  description: "Organization settings and health check endpoints",
+};
+
+export default function ConfigurationPage() {
+  return (
+    <div className="space-y-8">
+      {/* Header */}
+      <div className="space-y-4">
+        <div className="flex items-center gap-3">
+          <div className="p-2 rounded-lg bg-[var(--turquoise)]/10">
+            <Settings className="w-6 h-6 text-[var(--turquoise)]" />
+          </div>
+          <h1
+            className="text-3xl text-[var(--cream)]"
+            style={{ fontFamily: 'Georgia, "Times New Roman", serif' }}
+          >
+            Configuration
+          </h1>
+        </div>
+        <p className="text-lg text-[var(--cream)]/70">
+          Organization settings, API status, and health check endpoints for monitoring
+          your ABM.dev integration.
+        </p>
+      </div>
+
+      {/* Endpoints */}
+      <div className="space-y-4">
+        <h2 className="text-xl font-semibold text-[var(--cream)]">Endpoints</h2>
+
+        {/* Get Organization */}
+        <EndpointCard
+          id="organization"
+          method="GET"
+          path="/v1/organization"
+          title="Get Organization"
+          description="Retrieve details about your organization including plan, usage limits, and feature flags."
+          parameters={[]}
+          response={{
+            description: "Organization details and settings",
+            example: {
+              success: true,
+              data: {
+                id: "org_abc123xyz",
+                name: "ACME Corporation",
+                slug: "acme-corp",
+                plan: "pro",
+                created_at: "2025-01-15T10:00:00Z",
+                limits: {
+                  enrichments_per_month: 10000,
+                  api_requests_per_minute: 1000,
+                  team_members: 10,
+                  integrations: 5
+                },
+                usage: {
+                  enrichments_this_month: 2456,
+                  api_requests_today: 1892,
+                  team_members: 4,
+                  active_integrations: 2
+                },
+                features: {
+                  batch_enrichment: true,
+                  linkedin_enrichment: true,
+                  crm_integrations: true,
+                  webhooks: true,
+                  custom_fields: true,
+                  api_access: true
+                },
+                settings: {
+                  default_enrichment_fields: ["email", "name", "title", "company", "linkedin"],
+                  auto_enrich_new_contacts: false,
+                  webhook_url: "https://yourapp.com/webhooks/abmdev"
+                }
+              }
+            }
+          }}
+        />
+
+        {/* Health Check */}
+        <EndpointCard
+          id="status"
+          method="GET"
+          path="/v1/status"
+          title="Health Check"
+          description="Check the API status and health of all services. Use for monitoring and uptime checks."
+          parameters={[]}
+          response={{
+            description: "Service health status",
+            example: {
+              success: true,
+              status: "healthy",
+              version: "1.2.3",
+              timestamp: "2025-12-15T10:30:00Z",
+              services: {
+                api: "healthy",
+                database: "healthy",
+                enrichment: "healthy",
+                browser_pool: "healthy",
+                integrations: "healthy"
+              },
+              latency: {
+                api_ms: 12,
+                database_ms: 3,
+                enrichment_ms: 145
+              }
+            }
+          }}
+        />
+
+        {/* Update Organization Settings */}
+        <EndpointCard
+          id="update-settings"
+          method="PATCH"
+          path="/v1/organization/settings"
+          title="Update Settings"
+          description="Update organization settings like default enrichment fields, auto-enrichment, and webhook configuration."
+          parameters={[
+            { name: "default_enrichment_fields", type: "array", description: "Default fields to enrich for all contacts", location: "body" },
+            { name: "auto_enrich_new_contacts", type: "boolean", description: "Automatically enrich new contacts from CRM", location: "body" },
+            { name: "webhook_url", type: "string", description: "URL to receive webhook notifications", location: "body" },
+            { name: "webhook_events", type: "array", description: "Events to send webhooks for", location: "body" },
+          ]}
+          requestBody={{
+            description: "Settings to update",
+            example: {
+              default_enrichment_fields: ["email", "name", "title", "company", "linkedin", "phone"],
+              auto_enrich_new_contacts: true,
+              webhook_url: "https://yourapp.com/webhooks/abmdev",
+              webhook_events: ["enrichment.completed", "job.completed", "integration.sync"]
+            }
+          }}
+          response={{
+            description: "Updated settings",
+            example: {
+              success: true,
+              message: "Organization settings updated successfully",
+              data: {
+                default_enrichment_fields: ["email", "name", "title", "company", "linkedin", "phone"],
+                auto_enrich_new_contacts: true,
+                webhook_url: "https://yourapp.com/webhooks/abmdev",
+                webhook_events: ["enrichment.completed", "job.completed", "integration.sync"],
+                updated_at: "2025-12-15T10:30:00Z"
+              }
+            }
+          }}
+        />
+      </div>
+
+      {/* API Keys Info */}
+      <div className="space-y-4">
+        <h2 className="text-xl font-semibold text-[var(--cream)]">API Key Management</h2>
+        <div className="p-4 rounded-lg bg-[var(--dark-blue)]/50 border border-[var(--turquoise)]/20">
+          <p className="text-sm text-[var(--cream)]/70 mb-3">
+            API keys are managed through the developer portal dashboard, not via API.
+            This ensures proper audit logging and security controls.
+          </p>
+          <div className="flex gap-4 text-sm">
+            <a href="/api-keys" className="text-[var(--turquoise)] hover:underline">
+              Manage API Keys →
+            </a>
+          </div>
+        </div>
+      </div>
+
+      {/* Webhooks */}
+      <div className="space-y-4">
+        <h2 className="text-xl font-semibold text-[var(--cream)]">Webhook Events</h2>
+        <div className="rounded-lg border border-[var(--turquoise)]/20 overflow-hidden">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="bg-[var(--dark-blue)]/50 border-b border-[var(--turquoise)]/20">
+                <th className="text-left p-3 text-[var(--cream)]/60 font-medium">Event</th>
+                <th className="text-left p-3 text-[var(--cream)]/60 font-medium">Description</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr className="border-b border-[var(--turquoise)]/10">
+                <td className="p-3"><code className="text-[var(--turquoise)]">enrichment.completed</code></td>
+                <td className="p-3 text-[var(--cream)]/70">Single contact enrichment completed</td>
+              </tr>
+              <tr className="border-b border-[var(--turquoise)]/10">
+                <td className="p-3"><code className="text-[var(--turquoise)]">job.completed</code></td>
+                <td className="p-3 text-[var(--cream)]/70">Batch enrichment job completed</td>
+              </tr>
+              <tr className="border-b border-[var(--turquoise)]/10">
+                <td className="p-3"><code className="text-[var(--turquoise)]">job.failed</code></td>
+                <td className="p-3 text-[var(--cream)]/70">Batch enrichment job failed</td>
+              </tr>
+              <tr className="border-b border-[var(--turquoise)]/10">
+                <td className="p-3"><code className="text-[var(--turquoise)]">integration.connected</code></td>
+                <td className="p-3 text-[var(--cream)]/70">CRM integration connected</td>
+              </tr>
+              <tr className="border-b border-[var(--turquoise)]/10">
+                <td className="p-3"><code className="text-[var(--turquoise)]">integration.disconnected</code></td>
+                <td className="p-3 text-[var(--cream)]/70">CRM integration disconnected</td>
+              </tr>
+              <tr>
+                <td className="p-3"><code className="text-[var(--turquoise)]">integration.sync</code></td>
+                <td className="p-3 text-[var(--cream)]/70">CRM sync completed</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      {/* Webhook Payload */}
+      <div className="space-y-4">
+        <h2 className="text-xl font-semibold text-[var(--cream)]">Webhook Payload Format</h2>
+        <div className="rounded-lg overflow-hidden border border-[var(--turquoise)]/20 bg-[var(--navy)]">
+          <div className="flex items-center justify-between px-4 py-2 border-b border-[var(--turquoise)]/10 bg-[var(--dark-blue)]/50">
+            <span className="text-xs font-medium text-[var(--cream)]/60">Example Webhook Payload</span>
+          </div>
+          <pre className="p-4 overflow-x-auto text-sm">
+            <code className="text-[var(--cream)]/80 font-mono">{`{
+  "event": "enrichment.completed",
+  "timestamp": "2025-12-15T10:30:00Z",
+  "organization_id": "org_abc123xyz",
+  "data": {
+    "contact_email": "john@example.com",
+    "enrichment_id": "enr_xyz789",
+    "fields_enriched": ["title", "company", "linkedin"],
+    "confidence_score": 0.94
+  },
+  "signature": "sha256=..."
+}`}</code>
+          </pre>
+        </div>
+        <p className="text-sm text-[var(--cream)]/60">
+          Verify webhook authenticity by checking the <code className="text-[var(--turquoise)]">X-ABM-Signature</code> header
+          against the payload using your webhook secret.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/app/api-reference/enrichment/page.tsx
+++ b/app/api-reference/enrichment/page.tsx
@@ -1,0 +1,178 @@
+import { EndpointCard } from "@/components/api-reference";
+import { Zap } from "lucide-react";
+import Link from "next/link";
+
+export const metadata = {
+  title: "Enrichment API - ABM.dev",
+  description: "Enrich contact and company data with comprehensive information from multiple sources",
+};
+
+export default function EnrichmentPage() {
+  return (
+    <div className="space-y-8">
+      {/* Header */}
+      <div className="space-y-4">
+        <div className="flex items-center gap-3">
+          <div className="p-2 rounded-lg bg-[var(--turquoise)]/10">
+            <Zap className="w-6 h-6 text-[var(--turquoise)]" />
+          </div>
+          <h1
+            className="text-3xl text-[var(--cream)]"
+            style={{ fontFamily: 'Georgia, "Times New Roman", serif' }}
+          >
+            Enrichment
+          </h1>
+        </div>
+        <p className="text-lg text-[var(--cream)]/70">
+          Enrich contact and company data with comprehensive information from multiple data sources.
+          Supports both synchronous single-record and asynchronous batch enrichment.
+        </p>
+      </div>
+
+      {/* Related Docs */}
+      <div className="p-4 rounded-lg bg-[var(--turquoise)]/5 border border-[var(--turquoise)]/20">
+        <p className="text-sm text-[var(--cream)]/70">
+          <strong className="text-[var(--cream)]">Related:</strong>{" "}
+          <Link href="/docs/concepts/enrichment" className="text-[var(--turquoise)] hover:underline">
+            Enrichment Concepts
+          </Link>
+          {" | "}
+          <Link href="/docs/concepts/canonical-fields" className="text-[var(--turquoise)] hover:underline">
+            Canonical Fields
+          </Link>
+          {" | "}
+          <Link href="/docs/concepts/confidence-scores" className="text-[var(--turquoise)] hover:underline">
+            Confidence Scores
+          </Link>
+        </p>
+      </div>
+
+      {/* Endpoints */}
+      <div className="space-y-4">
+        <h2 className="text-xl font-semibold text-[var(--cream)]">Endpoints</h2>
+
+        {/* Enrich Contact */}
+        <EndpointCard
+          id="enrich"
+          method="POST"
+          path="/v1/enrich"
+          title="Enrich Contact"
+          description="Enrich a single contact with data from multiple sources. Returns enriched data synchronously for quick lookups. For bulk operations, use the batch endpoint."
+          parameters={[
+            { name: "email", type: "string", required: true, description: "Contact's email address", location: "body" },
+            { name: "linkedin_url", type: "string", description: "LinkedIn profile URL for enhanced enrichment", location: "body" },
+            { name: "first_name", type: "string", description: "First name to improve matching accuracy", location: "body" },
+            { name: "last_name", type: "string", description: "Last name to improve matching accuracy", location: "body" },
+            { name: "company", type: "string", description: "Company name for company enrichment", location: "body" },
+          ]}
+          requestBody={{
+            description: "Contact information to enrich",
+            example: {
+              email: "john.doe@example.com",
+              linkedin_url: "https://linkedin.com/in/johndoe",
+              first_name: "John",
+              last_name: "Doe",
+              company: "Example Corp"
+            }
+          }}
+          response={{
+            description: "Enriched contact data with confidence scores",
+            example: {
+              success: true,
+              data: {
+                email: "john.doe@example.com",
+                first_name: "John",
+                last_name: "Doe",
+                full_name: "John Doe",
+                title: "Senior Software Engineer",
+                company: "Example Corp",
+                company_domain: "example.com",
+                linkedin_url: "https://linkedin.com/in/johndoe",
+                location: "San Francisco, CA",
+                industry: "Technology",
+                confidence_scores: {
+                  email: 1.0,
+                  title: 0.95,
+                  company: 0.98,
+                  location: 0.85
+                },
+                sources: ["linkedin", "clearbit", "hunter"],
+                enriched_at: "2025-12-15T10:30:00Z"
+              }
+            }
+          }}
+        />
+
+        {/* Batch Enrich */}
+        <EndpointCard
+          id="batch"
+          method="POST"
+          path="/v1/enrich/batch"
+          title="Batch Enrich"
+          description="Submit multiple contacts for asynchronous enrichment. Returns a job ID that can be polled for results. Supports up to 100 contacts per batch."
+          parameters={[
+            { name: "contacts", type: "array", required: true, description: "Array of contact objects to enrich (max 100)", location: "body" },
+            { name: "webhook_url", type: "string", description: "URL to receive webhook notification when job completes", location: "body" },
+            { name: "priority", type: "string", description: "Job priority: 'normal' (default) or 'high'", location: "body" },
+          ]}
+          requestBody={{
+            description: "Array of contacts to enrich",
+            example: {
+              contacts: [
+                { email: "john@example.com", first_name: "John" },
+                { email: "jane@example.com", linkedin_url: "https://linkedin.com/in/jane" },
+                { email: "bob@acme.com", company: "ACME Inc" }
+              ],
+              webhook_url: "https://yourapp.com/webhooks/enrichment",
+              priority: "normal"
+            }
+          }}
+          response={{
+            description: "Job ID for tracking the batch enrichment",
+            example: {
+              success: true,
+              job_id: "job_abc123xyz",
+              status: "queued",
+              contacts_count: 3,
+              estimated_completion: "2025-12-15T10:35:00Z",
+              message: "Batch enrichment job created. Poll /v1/jobs/job_abc123xyz for status."
+            }
+          }}
+        />
+      </div>
+
+      {/* Error Codes */}
+      <div className="space-y-4">
+        <h2 className="text-xl font-semibold text-[var(--cream)]">Error Codes</h2>
+        <div className="rounded-lg border border-[var(--turquoise)]/20 overflow-hidden">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="bg-[var(--dark-blue)]/50 border-b border-[var(--turquoise)]/20">
+                <th className="text-left p-3 text-[var(--cream)]/60 font-medium">Code</th>
+                <th className="text-left p-3 text-[var(--cream)]/60 font-medium">Description</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr className="border-b border-[var(--turquoise)]/10">
+                <td className="p-3"><code className="text-amber-400">400</code></td>
+                <td className="p-3 text-[var(--cream)]/70">Invalid request body or missing required fields</td>
+              </tr>
+              <tr className="border-b border-[var(--turquoise)]/10">
+                <td className="p-3"><code className="text-amber-400">401</code></td>
+                <td className="p-3 text-[var(--cream)]/70">Invalid or missing API key</td>
+              </tr>
+              <tr className="border-b border-[var(--turquoise)]/10">
+                <td className="p-3"><code className="text-amber-400">422</code></td>
+                <td className="p-3 text-[var(--cream)]/70">Invalid email format or LinkedIn URL</td>
+              </tr>
+              <tr>
+                <td className="p-3"><code className="text-amber-400">429</code></td>
+                <td className="p-3 text-[var(--cream)]/70">Rate limit exceeded</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/api-reference/integrations/page.tsx
+++ b/app/api-reference/integrations/page.tsx
@@ -1,0 +1,238 @@
+import { EndpointCard } from "@/components/api-reference";
+import { Building2 } from "lucide-react";
+import Link from "next/link";
+
+export const metadata = {
+  title: "CRM Integrations API - ABM.dev",
+  description: "Configure and manage CRM integrations for HubSpot, Salesforce, and more",
+};
+
+export default function IntegrationsPage() {
+  return (
+    <div className="space-y-8">
+      {/* Header */}
+      <div className="space-y-4">
+        <div className="flex items-center gap-3">
+          <div className="p-2 rounded-lg bg-[var(--turquoise)]/10">
+            <Building2 className="w-6 h-6 text-[var(--turquoise)]" />
+          </div>
+          <h1
+            className="text-3xl text-[var(--cream)]"
+            style={{ fontFamily: 'Georgia, "Times New Roman", serif' }}
+          >
+            CRM Integrations
+          </h1>
+        </div>
+        <p className="text-lg text-[var(--cream)]/70">
+          Configure and manage CRM integrations to automatically sync enriched contact data
+          with HubSpot, Salesforce, and other platforms.
+        </p>
+      </div>
+
+      {/* Related Docs */}
+      <div className="p-4 rounded-lg bg-[var(--turquoise)]/5 border border-[var(--turquoise)]/20">
+        <p className="text-sm text-[var(--cream)]/70">
+          <strong className="text-[var(--cream)]">Related:</strong>{" "}
+          <Link href="/docs/guides/hubspot" className="text-[var(--turquoise)] hover:underline">
+            HubSpot Integration Guide
+          </Link>
+          {" | "}
+          <Link href="/docs/concepts/field-mapping" className="text-[var(--turquoise)] hover:underline">
+            Field Mapping
+          </Link>
+        </p>
+      </div>
+
+      {/* Supported CRMs */}
+      <div className="p-4 rounded-lg bg-[var(--dark-blue)]/50 border border-[var(--turquoise)]/20">
+        <h3 className="text-sm font-medium text-[var(--cream)] mb-3">Supported Platforms</h3>
+        <div className="flex flex-wrap gap-2">
+          <span className="px-3 py-1.5 rounded text-xs bg-[#ff7a59]/20 text-[#ff7a59] border border-[#ff7a59]/30">HubSpot</span>
+          <span className="px-3 py-1.5 rounded text-xs bg-[#00a1e0]/20 text-[#00a1e0] border border-[#00a1e0]/30">Salesforce</span>
+          <span className="px-3 py-1.5 rounded text-xs bg-gray-500/20 text-gray-400 border border-gray-500/30">More coming soon</span>
+        </div>
+      </div>
+
+      {/* Endpoints */}
+      <div className="space-y-4">
+        <h2 className="text-xl font-semibold text-[var(--cream)]">Endpoints</h2>
+
+        {/* List Integrations */}
+        <EndpointCard
+          id="list"
+          method="GET"
+          path="/v1/crm/config/integrations"
+          title="List Integrations"
+          description="Retrieve all configured CRM integrations for your organization, including their connection status and sync settings."
+          parameters={[]}
+          response={{
+            description: "List of configured integrations",
+            example: {
+              success: true,
+              data: [
+                {
+                  id: "int_hubspot_abc123",
+                  platform: "hubspot",
+                  status: "connected",
+                  portal_id: "12345678",
+                  connected_at: "2025-12-01T10:00:00Z",
+                  last_sync: "2025-12-15T14:30:00Z",
+                  sync_settings: {
+                    auto_sync: true,
+                    sync_frequency: "realtime",
+                    create_new_contacts: true,
+                    update_existing: true
+                  }
+                },
+                {
+                  id: "int_salesforce_def456",
+                  platform: "salesforce",
+                  status: "disconnected",
+                  instance_url: null,
+                  connected_at: null,
+                  last_sync: null,
+                  sync_settings: null
+                }
+              ]
+            }
+          }}
+        />
+
+        {/* Configure Integration */}
+        <EndpointCard
+          id="configure"
+          method="POST"
+          path="/v1/crm/config/integrations"
+          title="Configure Integration"
+          description="Configure a new CRM integration or update an existing one. Returns an OAuth URL for platforms requiring authorization."
+          parameters={[
+            { name: "platform", type: "string", required: true, description: "CRM platform: 'hubspot' or 'salesforce'", location: "body" },
+            { name: "auto_sync", type: "boolean", description: "Enable automatic sync of enriched data (default: true)", location: "body" },
+            { name: "sync_frequency", type: "string", description: "Sync frequency: 'realtime', 'hourly', 'daily' (default: 'realtime')", location: "body" },
+            { name: "create_new_contacts", type: "boolean", description: "Create contacts in CRM if they don't exist (default: true)", location: "body" },
+            { name: "update_existing", type: "boolean", description: "Update existing contacts with enriched data (default: true)", location: "body" },
+            { name: "field_mapping", type: "object", description: "Custom field mapping configuration", location: "body" },
+          ]}
+          requestBody={{
+            description: "Integration configuration",
+            example: {
+              platform: "hubspot",
+              auto_sync: true,
+              sync_frequency: "realtime",
+              create_new_contacts: true,
+              update_existing: true,
+              field_mapping: {
+                title: "jobtitle",
+                company: "company",
+                linkedin_url: "linkedin_url"
+              }
+            }
+          }}
+          response={{
+            description: "Integration created with OAuth URL if required",
+            example: {
+              success: true,
+              data: {
+                id: "int_hubspot_xyz789",
+                platform: "hubspot",
+                status: "pending_auth",
+                oauth_url: "https://app.hubspot.com/oauth/authorize?client_id=...",
+                message: "Redirect user to oauth_url to complete authorization"
+              }
+            }
+          }}
+        />
+
+        {/* Test Connection */}
+        <EndpointCard
+          id="test"
+          method="POST"
+          path="/v1/crm/config/integrations/test"
+          title="Test Connection"
+          description="Test the connection to a configured CRM integration. Verifies credentials and permissions are valid."
+          parameters={[
+            { name: "platform", type: "string", required: true, description: "CRM platform to test", location: "body" },
+          ]}
+          requestBody={{
+            description: "Platform to test",
+            example: {
+              platform: "hubspot"
+            }
+          }}
+          response={{
+            description: "Connection test results",
+            example: {
+              success: true,
+              data: {
+                platform: "hubspot",
+                connected: true,
+                portal_id: "12345678",
+                portal_name: "ACME Corp",
+                permissions: {
+                  contacts_read: true,
+                  contacts_write: true,
+                  companies_read: true,
+                  companies_write: true
+                },
+                latency_ms: 145,
+                tested_at: "2025-12-15T10:30:00Z"
+              }
+            }
+          }}
+        />
+
+        {/* Delete Integration */}
+        <EndpointCard
+          id="delete"
+          method="DELETE"
+          path="/v1/crm/config/integrations/{platform}"
+          title="Delete Integration"
+          description="Remove a CRM integration and revoke OAuth tokens. This does not delete any data that was synced to the CRM."
+          parameters={[
+            { name: "platform", type: "string", required: true, description: "CRM platform to disconnect", location: "path" },
+          ]}
+          response={{
+            description: "Confirmation of deletion",
+            example: {
+              success: true,
+              message: "HubSpot integration disconnected successfully",
+              data: {
+                platform: "hubspot",
+                deleted_at: "2025-12-15T10:30:00Z"
+              }
+            }
+          }}
+        />
+      </div>
+
+      {/* Webhooks Info */}
+      <div className="space-y-4">
+        <h2 className="text-xl font-semibold text-[var(--cream)]">Webhooks</h2>
+        <div className="p-4 rounded-lg bg-[var(--dark-blue)]/50 border border-[var(--turquoise)]/20">
+          <p className="text-sm text-[var(--cream)]/70 mb-3">
+            Receive webhook notifications when integration events occur. Configure your webhook URL in
+            the integration settings.
+          </p>
+          <div className="space-y-2">
+            <div className="flex items-center gap-2 text-sm">
+              <span className="px-2 py-0.5 rounded text-xs bg-emerald-500/20 text-emerald-400 border border-emerald-500/30">EVENT</span>
+              <code className="text-[var(--cream)]/60">integration.connected</code>
+            </div>
+            <div className="flex items-center gap-2 text-sm">
+              <span className="px-2 py-0.5 rounded text-xs bg-emerald-500/20 text-emerald-400 border border-emerald-500/30">EVENT</span>
+              <code className="text-[var(--cream)]/60">integration.disconnected</code>
+            </div>
+            <div className="flex items-center gap-2 text-sm">
+              <span className="px-2 py-0.5 rounded text-xs bg-emerald-500/20 text-emerald-400 border border-emerald-500/30">EVENT</span>
+              <code className="text-[var(--cream)]/60">sync.completed</code>
+            </div>
+            <div className="flex items-center gap-2 text-sm">
+              <span className="px-2 py-0.5 rounded text-xs bg-red-500/20 text-red-400 border border-red-500/30">EVENT</span>
+              <code className="text-[var(--cream)]/60">sync.failed</code>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/api-reference/jobs/page.tsx
+++ b/app/api-reference/jobs/page.tsx
@@ -1,0 +1,174 @@
+import { EndpointCard } from "@/components/api-reference";
+import { Briefcase } from "lucide-react";
+
+export const metadata = {
+  title: "Jobs API - ABM.dev",
+  description: "Monitor and manage asynchronous enrichment jobs",
+};
+
+export default function JobsPage() {
+  return (
+    <div className="space-y-8">
+      {/* Header */}
+      <div className="space-y-4">
+        <div className="flex items-center gap-3">
+          <div className="p-2 rounded-lg bg-[var(--turquoise)]/10">
+            <Briefcase className="w-6 h-6 text-[var(--turquoise)]" />
+          </div>
+          <h1
+            className="text-3xl text-[var(--cream)]"
+            style={{ fontFamily: 'Georgia, "Times New Roman", serif' }}
+          >
+            Jobs
+          </h1>
+        </div>
+        <p className="text-lg text-[var(--cream)]/70">
+          Monitor and manage asynchronous enrichment jobs. Jobs are created when using batch enrichment
+          and can be polled for status and results.
+        </p>
+      </div>
+
+      {/* Job Statuses */}
+      <div className="p-4 rounded-lg bg-[var(--dark-blue)]/50 border border-[var(--turquoise)]/20">
+        <h3 className="text-sm font-medium text-[var(--cream)] mb-3">Job Statuses</h3>
+        <div className="flex flex-wrap gap-2">
+          <span className="px-2 py-1 rounded text-xs bg-blue-500/20 text-blue-400 border border-blue-500/30">queued</span>
+          <span className="px-2 py-1 rounded text-xs bg-amber-500/20 text-amber-400 border border-amber-500/30">processing</span>
+          <span className="px-2 py-1 rounded text-xs bg-emerald-500/20 text-emerald-400 border border-emerald-500/30">completed</span>
+          <span className="px-2 py-1 rounded text-xs bg-red-500/20 text-red-400 border border-red-500/30">failed</span>
+          <span className="px-2 py-1 rounded text-xs bg-purple-500/20 text-purple-400 border border-purple-500/30">partial</span>
+        </div>
+      </div>
+
+      {/* Endpoints */}
+      <div className="space-y-4">
+        <h2 className="text-xl font-semibold text-[var(--cream)]">Endpoints</h2>
+
+        {/* List Jobs */}
+        <EndpointCard
+          id="list"
+          method="GET"
+          path="/v1/jobs"
+          title="List Jobs"
+          description="Retrieve a list of enrichment jobs for your organization. Supports pagination and filtering by status."
+          parameters={[
+            { name: "status", type: "string", description: "Filter by job status (queued, processing, completed, failed)", location: "query" },
+            { name: "limit", type: "number", description: "Number of jobs to return (default: 20, max: 100)", location: "query" },
+            { name: "offset", type: "number", description: "Number of jobs to skip for pagination", location: "query" },
+          ]}
+          response={{
+            description: "List of jobs with pagination info",
+            example: {
+              success: true,
+              data: [
+                {
+                  id: "job_abc123xyz",
+                  status: "completed",
+                  contacts_count: 50,
+                  enriched_count: 48,
+                  failed_count: 2,
+                  created_at: "2025-12-15T10:30:00Z",
+                  completed_at: "2025-12-15T10:32:15Z"
+                },
+                {
+                  id: "job_def456uvw",
+                  status: "processing",
+                  contacts_count: 100,
+                  enriched_count: 45,
+                  failed_count: 0,
+                  created_at: "2025-12-15T10:35:00Z",
+                  completed_at: null
+                }
+              ],
+              pagination: {
+                total: 156,
+                limit: 20,
+                offset: 0,
+                has_more: true
+              }
+            }
+          }}
+        />
+
+        {/* Get Job */}
+        <EndpointCard
+          id="get"
+          method="GET"
+          path="/v1/jobs/{id}"
+          title="Get Job Details"
+          description="Retrieve detailed information about a specific enrichment job, including progress and any errors."
+          parameters={[
+            { name: "id", type: "string", required: true, description: "Job ID returned from batch enrichment", location: "path" },
+          ]}
+          response={{
+            description: "Detailed job information",
+            example: {
+              success: true,
+              data: {
+                id: "job_abc123xyz",
+                status: "completed",
+                contacts_count: 50,
+                enriched_count: 48,
+                failed_count: 2,
+                progress_percentage: 100,
+                created_at: "2025-12-15T10:30:00Z",
+                started_at: "2025-12-15T10:30:05Z",
+                completed_at: "2025-12-15T10:32:15Z",
+                duration_seconds: 130,
+                errors: [
+                  { contact_index: 12, email: "invalid@", error: "Invalid email format" },
+                  { contact_index: 37, email: "notfound@example.com", error: "No data found" }
+                ]
+              }
+            }
+          }}
+        />
+
+        {/* Get Job Results */}
+        <EndpointCard
+          id="results"
+          method="GET"
+          path="/v1/jobs/{id}/results"
+          title="Get Job Results"
+          description="Retrieve the enriched contact data from a completed job. Only available for jobs with status 'completed' or 'partial'."
+          parameters={[
+            { name: "id", type: "string", required: true, description: "Job ID", location: "path" },
+            { name: "format", type: "string", description: "Response format: 'json' (default) or 'csv'", location: "query" },
+            { name: "include_failed", type: "boolean", description: "Include failed contacts in results (default: false)", location: "query" },
+          ]}
+          response={{
+            description: "Array of enriched contacts",
+            example: {
+              success: true,
+              job_id: "job_abc123xyz",
+              data: [
+                {
+                  original: { email: "john@example.com" },
+                  enriched: {
+                    email: "john@example.com",
+                    full_name: "John Smith",
+                    title: "Product Manager",
+                    company: "Example Corp",
+                    confidence_scores: { email: 1.0, title: 0.92 }
+                  },
+                  status: "success"
+                },
+                {
+                  original: { email: "jane@acme.com" },
+                  enriched: {
+                    email: "jane@acme.com",
+                    full_name: "Jane Doe",
+                    title: "CTO",
+                    company: "ACME Inc"
+                  },
+                  status: "success"
+                }
+              ],
+              total: 48
+            }
+          }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/app/api-reference/layout.tsx
+++ b/app/api-reference/layout.tsx
@@ -1,14 +1,27 @@
-import { Navigation } from '@/components/shared/Navigation'
+import { Navigation } from "@/components/shared/Navigation";
+import { ApiSidebar } from "@/components/api-reference/ApiSidebar";
+
+export const metadata = {
+  title: "API Reference - ABM.dev",
+  description: "Complete API documentation for ABM.dev enrichment and integration APIs",
+};
 
 export default function ApiReferenceLayout({
   children,
 }: {
-  children: React.ReactNode
+  children: React.ReactNode;
 }) {
   return (
     <div className="min-h-screen bg-[var(--dark-blue)]">
       <Navigation />
-      {children}
+      <div className="container mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <div className="flex gap-8">
+          <ApiSidebar />
+          <main id="main-content" className="flex-1 min-w-0 max-w-4xl">
+            {children}
+          </main>
+        </div>
+      </div>
     </div>
-  )
+  );
 }

--- a/app/api-reference/linkedin/page.tsx
+++ b/app/api-reference/linkedin/page.tsx
@@ -1,0 +1,280 @@
+import { EndpointCard } from "@/components/api-reference";
+import { Linkedin } from "lucide-react";
+import Link from "next/link";
+
+export const metadata = {
+  title: "LinkedIn Connection API - ABM.dev",
+  description: "Manage LinkedIn browser sessions for enhanced profile enrichment",
+};
+
+export default function LinkedInPage() {
+  return (
+    <div className="space-y-8">
+      {/* Header */}
+      <div className="space-y-4">
+        <div className="flex items-center gap-3">
+          <div className="p-2 rounded-lg bg-[var(--turquoise)]/10">
+            <Linkedin className="w-6 h-6 text-[var(--turquoise)]" />
+          </div>
+          <h1
+            className="text-3xl text-[var(--cream)]"
+            style={{ fontFamily: 'Georgia, "Times New Roman", serif' }}
+          >
+            LinkedIn Connection
+          </h1>
+        </div>
+        <p className="text-lg text-[var(--cream)]/70">
+          Manage LinkedIn browser sessions to enable enhanced profile enrichment. LinkedIn connections
+          provide higher quality data including profile photos, recent activity, and verified information.
+        </p>
+      </div>
+
+      {/* Related Docs */}
+      <div className="p-4 rounded-lg bg-[var(--turquoise)]/5 border border-[var(--turquoise)]/20">
+        <p className="text-sm text-[var(--cream)]/70">
+          <strong className="text-[var(--cream)]">Related:</strong>{" "}
+          <Link href="/docs/guides/linkedin" className="text-[var(--turquoise)] hover:underline">
+            LinkedIn Integration Guide
+          </Link>
+          {" | "}
+          <Link href="/docs/concepts/data-sources" className="text-[var(--turquoise)] hover:underline">
+            Data Sources
+          </Link>
+        </p>
+      </div>
+
+      {/* Connection Flow */}
+      <div className="p-4 rounded-lg bg-[var(--dark-blue)]/50 border border-[var(--turquoise)]/20">
+        <h3 className="text-sm font-medium text-[var(--cream)] mb-3">Connection Flow</h3>
+        <div className="flex items-center gap-2 text-sm text-[var(--cream)]/70 flex-wrap">
+          <span className="px-2 py-1 rounded bg-blue-500/20 text-blue-400 border border-blue-500/30">1. Initialize</span>
+          <span className="text-[var(--cream)]/40">→</span>
+          <span className="px-2 py-1 rounded bg-amber-500/20 text-amber-400 border border-amber-500/30">2. User Login</span>
+          <span className="text-[var(--cream)]/40">→</span>
+          <span className="px-2 py-1 rounded bg-purple-500/20 text-purple-400 border border-purple-500/30">3. Verify</span>
+          <span className="text-[var(--cream)]/40">→</span>
+          <span className="px-2 py-1 rounded bg-emerald-500/20 text-emerald-400 border border-emerald-500/30">4. Connected</span>
+        </div>
+      </div>
+
+      {/* Endpoints */}
+      <div className="space-y-4">
+        <h2 className="text-xl font-semibold text-[var(--cream)]">Endpoints</h2>
+
+        {/* Initialize */}
+        <EndpointCard
+          id="initialize"
+          method="POST"
+          path="/v1/linkedin-connection/initialize"
+          title="Initialize Connection"
+          description="Start a new LinkedIn connection session. Returns a browser session URL where the user can log in to their LinkedIn account."
+          parameters={[]}
+          response={{
+            description: "Session initialization with connect URL",
+            example: {
+              success: true,
+              data: {
+                session_id: "sess_abc123xyz",
+                connect_url: "https://browser.abm.dev/session/sess_abc123xyz",
+                expires_at: "2025-12-15T10:45:00Z",
+                status: "awaiting_login"
+              }
+            }
+          }}
+        />
+
+        {/* Verify */}
+        <EndpointCard
+          id="verify"
+          method="POST"
+          path="/v1/linkedin-connection/verify"
+          title="Verify Login"
+          description="Verify that the user has successfully logged in to LinkedIn. Call this after the user completes the login flow in the browser session."
+          parameters={[
+            { name: "session_id", type: "string", required: true, description: "Session ID from initialize response", location: "body" },
+          ]}
+          requestBody={{
+            description: "Session to verify",
+            example: {
+              session_id: "sess_abc123xyz"
+            }
+          }}
+          response={{
+            description: "Verification result",
+            example: {
+              success: true,
+              data: {
+                verified: true,
+                linkedin_profile: {
+                  name: "John Doe",
+                  headline: "Software Engineer at Example Corp",
+                  profile_url: "https://linkedin.com/in/johndoe"
+                },
+                connection_status: "connected",
+                expires_at: "2025-12-22T10:30:00Z"
+              }
+            }
+          }}
+        />
+
+        {/* Get Status */}
+        <EndpointCard
+          id="status"
+          method="GET"
+          path="/v1/linkedin-connection/status"
+          title="Get Connection Status"
+          description="Check the current status of your LinkedIn connection, including session health and expiration."
+          parameters={[]}
+          response={{
+            description: "Current connection status",
+            example: {
+              success: true,
+              data: {
+                connected: true,
+                status: "active",
+                linkedin_profile: {
+                  name: "John Doe",
+                  headline: "Software Engineer at Example Corp",
+                  profile_url: "https://linkedin.com/in/johndoe"
+                },
+                connected_at: "2025-12-15T10:30:00Z",
+                expires_at: "2025-12-22T10:30:00Z",
+                enrichments_today: 45,
+                daily_limit: 100
+              }
+            }
+          }}
+        />
+
+        {/* Check Availability */}
+        <EndpointCard
+          id="availability"
+          method="GET"
+          path="/v1/linkedin-connection/availability"
+          title="Check Availability"
+          description="Check if a browser session is available for a new LinkedIn connection. Sessions are limited to prevent rate limiting."
+          parameters={[]}
+          response={{
+            description: "Session availability status",
+            example: {
+              success: true,
+              data: {
+                available: true,
+                active_sessions: 0,
+                max_sessions: 1,
+                estimated_wait_time: null
+              }
+            }
+          }}
+        />
+
+        {/* Disconnect */}
+        <EndpointCard
+          id="disconnect"
+          method="DELETE"
+          path="/v1/linkedin-connection"
+          title="Disconnect"
+          description="Disconnect your LinkedIn session and clear stored credentials. You will need to re-authenticate to use LinkedIn enrichment."
+          parameters={[]}
+          response={{
+            description: "Confirmation of disconnection",
+            example: {
+              success: true,
+              message: "LinkedIn connection disconnected successfully",
+              data: {
+                disconnected_at: "2025-12-15T10:30:00Z"
+              }
+            }
+          }}
+        />
+
+        {/* Cleanup Sessions (Admin) */}
+        <EndpointCard
+          id="cleanup"
+          method="POST"
+          path="/v1/linkedin-connection/sessions/cleanup"
+          title="Cleanup Sessions"
+          description="Force cleanup of stale browser sessions. Use this if you're getting 'session limit reached' errors. Admin operation."
+          parameters={[]}
+          response={{
+            description: "Cleanup results",
+            example: {
+              success: true,
+              data: {
+                cleaned_sessions: 1,
+                total_found: 1,
+                message: "Successfully cleaned up 1 stale session(s)"
+              }
+            }
+          }}
+        />
+      </div>
+
+      {/* Rate Limits */}
+      <div className="space-y-4">
+        <h2 className="text-xl font-semibold text-[var(--cream)]">Rate Limits</h2>
+        <div className="rounded-lg border border-[var(--turquoise)]/20 overflow-hidden">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="bg-[var(--dark-blue)]/50 border-b border-[var(--turquoise)]/20">
+                <th className="text-left p-3 text-[var(--cream)]/60 font-medium">Limit Type</th>
+                <th className="text-left p-3 text-[var(--cream)]/60 font-medium">Value</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr className="border-b border-[var(--turquoise)]/10">
+                <td className="p-3 text-[var(--cream)]/70">Concurrent sessions</td>
+                <td className="p-3"><code className="text-[var(--turquoise)]">1</code></td>
+              </tr>
+              <tr className="border-b border-[var(--turquoise)]/10">
+                <td className="p-3 text-[var(--cream)]/70">Enrichments per day</td>
+                <td className="p-3"><code className="text-[var(--turquoise)]">100</code></td>
+              </tr>
+              <tr className="border-b border-[var(--turquoise)]/10">
+                <td className="p-3 text-[var(--cream)]/70">Session timeout</td>
+                <td className="p-3"><code className="text-[var(--turquoise)]">15 minutes</code></td>
+              </tr>
+              <tr>
+                <td className="p-3 text-[var(--cream)]/70">Connection expiry</td>
+                <td className="p-3"><code className="text-[var(--turquoise)]">7 days</code></td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      {/* Troubleshooting */}
+      <div className="space-y-4">
+        <h2 className="text-xl font-semibold text-[var(--cream)]">Troubleshooting</h2>
+        <div className="rounded-lg border border-[var(--turquoise)]/20 overflow-hidden">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="bg-[var(--dark-blue)]/50 border-b border-[var(--turquoise)]/20">
+                <th className="text-left p-3 text-[var(--cream)]/60 font-medium">Error</th>
+                <th className="text-left p-3 text-[var(--cream)]/60 font-medium">Solution</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr className="border-b border-[var(--turquoise)]/10">
+                <td className="p-3"><code className="text-amber-400">SESSION_LIMIT_REACHED</code></td>
+                <td className="p-3 text-[var(--cream)]/70">Call /sessions/cleanup endpoint or wait for current session to expire</td>
+              </tr>
+              <tr className="border-b border-[var(--turquoise)]/10">
+                <td className="p-3"><code className="text-amber-400">SESSION_EXPIRED</code></td>
+                <td className="p-3 text-[var(--cream)]/70">Initialize a new session and complete login again</td>
+              </tr>
+              <tr className="border-b border-[var(--turquoise)]/10">
+                <td className="p-3"><code className="text-amber-400">VERIFICATION_FAILED</code></td>
+                <td className="p-3 text-[var(--cream)]/70">Ensure LinkedIn login was completed successfully in the browser</td>
+              </tr>
+              <tr>
+                <td className="p-3"><code className="text-amber-400">RATE_LIMITED</code></td>
+                <td className="p-3 text-[var(--cream)]/70">Daily enrichment limit reached, wait until reset at midnight UTC</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/api-reference/loading.tsx
+++ b/app/api-reference/loading.tsx
@@ -1,0 +1,61 @@
+import { Skeleton } from '@/components/ui/skeleton';
+
+export default function ApiReferenceLoading() {
+  return (
+    <div className="space-y-8">
+      {/* Header Skeleton */}
+      <div className="space-y-4">
+        <Skeleton className="h-9 w-40" />
+        <Skeleton className="h-5 w-96" />
+      </div>
+
+      {/* Base URL Skeleton */}
+      <div className="p-4 rounded-lg bg-[var(--dark-blue)]/50 border border-[var(--turquoise)]/20">
+        <Skeleton className="h-4 w-20 mb-2" />
+        <Skeleton className="h-5 w-48" />
+      </div>
+
+      {/* Authentication Skeleton */}
+      <div className="p-4 rounded-lg bg-[var(--dark-blue)]/50 border border-[var(--turquoise)]/20">
+        <Skeleton className="h-5 w-32 mb-2" />
+        <Skeleton className="h-4 w-80 mb-3" />
+        <Skeleton className="h-12 w-full rounded" />
+      </div>
+
+      {/* Endpoints Section Skeleton */}
+      <div className="space-y-4">
+        <Skeleton className="h-7 w-28" />
+        <div className="grid gap-4">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <div
+              key={i}
+              className="p-4 rounded-lg bg-[var(--dark-blue)]/50 border border-[var(--turquoise)]/20"
+            >
+              <div className="flex items-start justify-between mb-3">
+                <div className="flex items-center gap-3">
+                  <Skeleton className="h-10 w-10 rounded-lg" />
+                  <div className="space-y-2">
+                    <Skeleton className="h-5 w-32" />
+                    <Skeleton className="h-4 w-64" />
+                  </div>
+                </div>
+                <Skeleton className="h-4 w-4" />
+              </div>
+              <div className="flex flex-wrap gap-2">
+                {Array.from({ length: 3 }).map((_, j) => (
+                  <Skeleton key={j} className="h-6 w-32 rounded" />
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Rate Limits Skeleton */}
+      <div className="p-4 rounded-lg bg-[var(--dark-blue)]/50 border border-[var(--turquoise)]/20">
+        <Skeleton className="h-5 w-28 mb-2" />
+        <Skeleton className="h-4 w-full" />
+      </div>
+    </div>
+  );
+}

--- a/app/api-reference/page.tsx
+++ b/app/api-reference/page.tsx
@@ -1,25 +1,163 @@
-import { ApiReference } from '@/components/api-reference';
+import Link from "next/link";
+import { MethodBadge } from "@/components/api-reference";
+import { Zap, Briefcase, Building2, Linkedin, Settings, Key, ArrowRight } from "lucide-react";
 
 export const metadata = {
-  title: 'API Reference - ABM.dev Developer Portal',
-  description: 'Interactive API documentation for the ABM.dev GTM Intelligence API',
+  title: "API Reference - ABM.dev Developer Portal",
+  description: "Complete API documentation for ABM.dev enrichment and integration APIs",
 };
+
+const apiCategories = [
+  {
+    title: "Enrichment",
+    description: "Enrich contact and company data with comprehensive information from multiple sources.",
+    href: "/api-reference/enrichment",
+    icon: Zap,
+    endpoints: [
+      { method: "POST" as const, path: "/v1/enrich", title: "Single enrichment" },
+      { method: "POST" as const, path: "/v1/enrich/batch", title: "Batch enrichment" },
+    ],
+  },
+  {
+    title: "Jobs",
+    description: "Monitor and manage asynchronous enrichment jobs.",
+    href: "/api-reference/jobs",
+    icon: Briefcase,
+    endpoints: [
+      { method: "GET" as const, path: "/v1/jobs", title: "List jobs" },
+      { method: "GET" as const, path: "/v1/jobs/{id}", title: "Get job details" },
+      { method: "GET" as const, path: "/v1/jobs/{id}/results", title: "Get results" },
+    ],
+  },
+  {
+    title: "CRM Integrations",
+    description: "Configure and manage CRM integrations for HubSpot, Salesforce, and more.",
+    href: "/api-reference/integrations",
+    icon: Building2,
+    endpoints: [
+      { method: "GET" as const, path: "/v1/crm/config/integrations", title: "List integrations" },
+      { method: "POST" as const, path: "/v1/crm/config/integrations", title: "Configure" },
+      { method: "POST" as const, path: "/v1/crm/config/integrations/test", title: "Test connection" },
+    ],
+  },
+  {
+    title: "LinkedIn Connection",
+    description: "Manage LinkedIn browser sessions for enhanced profile enrichment.",
+    href: "/api-reference/linkedin",
+    icon: Linkedin,
+    endpoints: [
+      { method: "POST" as const, path: "/v1/linkedin-connection/initialize", title: "Initialize" },
+      { method: "POST" as const, path: "/v1/linkedin-connection/verify", title: "Verify login" },
+      { method: "GET" as const, path: "/v1/linkedin-connection/status", title: "Get status" },
+    ],
+  },
+  {
+    title: "Configuration",
+    description: "Organization settings and health check endpoints.",
+    href: "/api-reference/configuration",
+    icon: Settings,
+    endpoints: [
+      { method: "GET" as const, path: "/v1/organization", title: "Get organization" },
+      { method: "GET" as const, path: "/v1/status", title: "Health check" },
+    ],
+  },
+];
 
 export default function ApiReferencePage() {
   return (
-    <div className="max-w-[1600px] mx-auto px-4 sm:px-6 lg:px-8 py-8">
-      <div className="space-y-4 mb-6">
+    <div className="space-y-8">
+      {/* Header */}
+      <div className="space-y-4">
         <h1
           className="text-3xl text-[var(--cream)]"
           style={{ fontFamily: 'Georgia, "Times New Roman", serif' }}
         >
           API Reference
         </h1>
-        <p className="text-[var(--cream)]/70">
-          Explore and test the ABM.dev API endpoints. Sign in to use the interactive Try It console.
+        <p className="text-lg text-[var(--cream)]/70">
+          Complete documentation for the ABM.dev REST API. All endpoints require authentication via API key.
         </p>
       </div>
-      <ApiReference />
+
+      {/* Base URL */}
+      <div className="p-4 rounded-lg bg-[var(--dark-blue)]/50 border border-[var(--turquoise)]/20">
+        <h2 className="text-sm font-medium text-[var(--cream)]/60 mb-2">Base URL</h2>
+        <code className="text-[var(--turquoise)] font-mono">https://api.abm.dev</code>
+      </div>
+
+      {/* Authentication */}
+      <div className="p-4 rounded-lg bg-[var(--dark-blue)]/50 border border-[var(--turquoise)]/20">
+        <div className="flex items-start justify-between">
+          <div>
+            <h2 className="text-sm font-medium text-[var(--cream)] mb-2 flex items-center gap-2">
+              <Key className="w-4 h-4 text-[var(--turquoise)]" />
+              Authentication
+            </h2>
+            <p className="text-sm text-[var(--cream)]/60 mb-3">
+              Include your API key in the <code className="text-[var(--turquoise)]">X-API-Key</code> header with all requests.
+            </p>
+            <pre className="p-3 rounded bg-[var(--navy)] text-sm font-mono text-[var(--cream)]/80">
+              X-API-Key: your_api_key_here
+            </pre>
+          </div>
+          <Link
+            href="/api-keys"
+            className="text-sm text-[var(--turquoise)] hover:underline flex items-center gap-1"
+          >
+            Get API Key
+            <ArrowRight className="w-3 h-3" />
+          </Link>
+        </div>
+      </div>
+
+      {/* Category Cards */}
+      <div className="space-y-4">
+        <h2 className="text-xl font-semibold text-[var(--cream)]">Endpoints</h2>
+        <div className="grid gap-4">
+          {apiCategories.map((category) => (
+            <Link
+              key={category.title}
+              href={category.href}
+              className="group p-4 rounded-lg bg-[var(--dark-blue)]/50 border border-[var(--turquoise)]/20 hover:border-[var(--turquoise)]/40 hover:bg-[var(--turquoise)]/5 transition-all"
+            >
+              <div className="flex items-start justify-between mb-3">
+                <div className="flex items-center gap-3">
+                  <div className="p-2 rounded-lg bg-[var(--turquoise)]/10">
+                    <category.icon className="w-5 h-5 text-[var(--turquoise)]" />
+                  </div>
+                  <div>
+                    <h3 className="font-medium text-[var(--cream)] group-hover:text-[var(--turquoise)] transition-colors">
+                      {category.title}
+                    </h3>
+                    <p className="text-sm text-[var(--cream)]/60">{category.description}</p>
+                  </div>
+                </div>
+                <ArrowRight className="w-4 h-4 text-[var(--cream)]/40 group-hover:text-[var(--turquoise)] group-hover:translate-x-1 transition-all" />
+              </div>
+              <div className="flex flex-wrap gap-2">
+                {category.endpoints.map((endpoint) => (
+                  <div
+                    key={endpoint.path}
+                    className="flex items-center gap-2 px-2 py-1 rounded bg-[var(--navy)] text-xs"
+                  >
+                    <MethodBadge method={endpoint.method} className="text-[10px] px-1" />
+                    <code className="text-[var(--cream)]/60 font-mono">{endpoint.path}</code>
+                  </div>
+                ))}
+              </div>
+            </Link>
+          ))}
+        </div>
+      </div>
+
+      {/* Rate Limits */}
+      <div className="p-4 rounded-lg bg-[var(--dark-blue)]/50 border border-[var(--turquoise)]/20">
+        <h2 className="text-sm font-medium text-[var(--cream)] mb-2">Rate Limits</h2>
+        <p className="text-sm text-[var(--cream)]/60">
+          API requests are rate limited based on your plan. Free tier: 100 requests/minute.
+          Pro tier: 1,000 requests/minute. Enterprise: Custom limits.
+        </p>
+      </div>
     </div>
   );
 }

--- a/app/docs/advanced/enrichment-config/page.tsx
+++ b/app/docs/advanced/enrichment-config/page.tsx
@@ -1,0 +1,543 @@
+"use client";
+
+import Link from "next/link";
+import { Badge } from "@/components/ui/badge";
+import { Callout } from "@/components/docs/Callout";
+import { CodeBlock } from "@/components/docs/CodeBlock";
+import {
+  Clock,
+  Settings,
+  Cpu,
+  Database,
+  ArrowRight,
+  Sliders,
+  Sparkles,
+  Shield,
+  Gauge
+} from "lucide-react";
+
+const configOptions = [
+  {
+    name: "sources",
+    type: "string[]",
+    default: '["linkedin", "hunter", "perplexity", "tavily"]',
+    description: "Which data sources to query during enrichment",
+  },
+  {
+    name: "require_linkedin",
+    type: "boolean",
+    default: "false",
+    description: "Fail enrichment if LinkedIn data is unavailable",
+  },
+  {
+    name: "enable_auditor",
+    type: "boolean",
+    default: "true",
+    description: "Enable AI auditor to verify enrichment quality",
+  },
+  {
+    name: "min_confidence_to_proceed",
+    type: "number",
+    default: "0.5",
+    description: "Minimum confidence score (0-1) to continue enrichment",
+  },
+  {
+    name: "auto_proceed",
+    type: "boolean",
+    default: "true",
+    description: "Automatically proceed with CRM writeback after enrichment",
+  },
+  {
+    name: "preflight_only",
+    type: "boolean",
+    default: "false",
+    description: "Only run preflight checks, don't execute enrichment",
+  },
+  {
+    name: "enable_hubspot_writeback",
+    type: "boolean",
+    default: "true",
+    description: "Write enriched data back to HubSpot automatically",
+  },
+];
+
+const modelOptions = [
+  {
+    name: "Claude Sonnet 4",
+    id: "claude-sonnet-4-20250514",
+    role: "Writer (default)",
+    description: "Fast, high-quality synthesis for generating narrative fields and summaries",
+    cost: "$$",
+  },
+  {
+    name: "Claude Opus 4",
+    id: "claude-opus-4-20250514",
+    role: "Writer (premium)",
+    description: "Highest quality output for complex synthesis tasks",
+    cost: "$$$",
+  },
+  {
+    name: "Claude Haiku 3.5",
+    id: "claude-3-5-haiku-20241022",
+    role: "Auditor (default)",
+    description: "Fast, efficient verification and quality checks",
+    cost: "$",
+  },
+];
+
+export default function EnrichmentConfigPage() {
+  return (
+    <div className="space-y-12">
+      {/* Header */}
+      <div className="space-y-4">
+        <div className="flex items-center gap-2">
+          <Badge className="bg-[var(--turquoise)]/20 text-[var(--turquoise)] border-[var(--turquoise)]/30">
+            <Clock className="w-3 h-3 mr-1" />
+            12 min read
+          </Badge>
+          <Badge variant="secondary" className="bg-[var(--warning-yellow)]/10 text-[var(--warning-yellow)] border-[var(--warning-yellow)]/30">
+            Advanced
+          </Badge>
+        </div>
+        <h1 className="text-3xl lg:text-4xl font-serif text-[var(--cream)]">
+          Enrichment Configuration
+        </h1>
+        <p className="text-lg text-[var(--cream)]/70 max-w-2xl">
+          Fine-tune every aspect of the enrichment pipeline. Configure data sources,
+          AI models, confidence thresholds, and processing behavior.
+        </p>
+      </div>
+
+      {/* Configuration Options */}
+      <section className="space-y-4">
+        <h2 className="text-xl font-semibold text-[var(--cream)] flex items-center gap-2">
+          <Sliders className="w-5 h-5 text-[var(--turquoise)]" />
+          Configuration Options
+        </h2>
+
+        <p className="text-[var(--cream)]/70">
+          Pass these options in your enrichment request to customize behavior:
+        </p>
+
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-[var(--turquoise)]/20">
+                <th className="text-left py-3 pr-4 text-[var(--cream)]">Option</th>
+                <th className="text-left py-3 pr-4 text-[var(--cream)]">Type</th>
+                <th className="text-left py-3 pr-4 text-[var(--cream)]">Default</th>
+                <th className="text-left py-3 text-[var(--cream)]">Description</th>
+              </tr>
+            </thead>
+            <tbody className="text-[var(--cream)]/70">
+              {configOptions.map((option) => (
+                <tr key={option.name} className="border-b border-[var(--turquoise)]/10">
+                  <td className="py-3 pr-4">
+                    <code className="text-xs px-1.5 py-0.5 rounded bg-[var(--turquoise)]/10 text-[var(--turquoise)]">
+                      {option.name}
+                    </code>
+                  </td>
+                  <td className="py-3 pr-4 text-[var(--cream)]/50 font-mono text-xs">
+                    {option.type}
+                  </td>
+                  <td className="py-3 pr-4 font-mono text-xs">{option.default}</td>
+                  <td className="py-3">{option.description}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      {/* Full Config Example */}
+      <section className="space-y-4">
+        <h2 className="text-xl font-semibold text-[var(--cream)] flex items-center gap-2">
+          <Settings className="w-5 h-5 text-[var(--turquoise)]" />
+          Full Configuration Example
+        </h2>
+
+        <CodeBlock
+          title="Complete enrichment configuration"
+          examples={{
+            javascript: `// Full configuration for enrichment request
+const result = await abmdev.enrich({
+  // Input data
+  email: "jane@acme.com",
+  linkedin_url: "linkedin.com/in/janesmith",
+
+  // Source configuration
+  sources: ["linkedin", "hunter", "perplexity"],
+  require_linkedin: true,
+
+  // AI configuration
+  enable_auditor: true,
+  models: {
+    writer: {
+      provider: "anthropic",
+      model: "claude-sonnet-4-20250514"
+    },
+    auditor: {
+      provider: "anthropic",
+      model: "claude-3-5-haiku-20241022"
+    }
+  },
+
+  // Custom prompts (optional)
+  person_system_prompt: \`You are enriching a B2B contact.
+Focus on professional background, decision-making authority,
+and technology interests. Be concise.\`,
+
+  // Quality controls
+  min_confidence_to_proceed: 0.7,
+  auto_proceed: false,        // Review before CRM writeback
+
+  // CRM integration
+  enable_hubspot_writeback: true,
+  hubspot_contact_id: "12345" // Optional: update specific contact
+});`,
+            python: `# Full configuration for enrichment request
+result = abmdev.enrich(
+    # Input data
+    email="jane@acme.com",
+    linkedin_url="linkedin.com/in/janesmith",
+
+    # Source configuration
+    sources=["linkedin", "hunter", "perplexity"],
+    require_linkedin=True,
+
+    # AI configuration
+    enable_auditor=True,
+    models={
+        "writer": {
+            "provider": "anthropic",
+            "model": "claude-sonnet-4-20250514"
+        },
+        "auditor": {
+            "provider": "anthropic",
+            "model": "claude-3-5-haiku-20241022"
+        }
+    },
+
+    # Custom prompts (optional)
+    person_system_prompt="""You are enriching a B2B contact.
+Focus on professional background, decision-making authority,
+and technology interests. Be concise.""",
+
+    # Quality controls
+    min_confidence_to_proceed=0.7,
+    auto_proceed=False,  # Review before CRM writeback
+
+    # CRM integration
+    enable_hubspot_writeback=True,
+    hubspot_contact_id="12345"  # Optional: update specific contact
+)`,
+          }}
+        />
+      </section>
+
+      {/* AI Model Configuration */}
+      <section className="space-y-4">
+        <h2 className="text-xl font-semibold text-[var(--cream)] flex items-center gap-2">
+          <Cpu className="w-5 h-5 text-[var(--turquoise)]" />
+          AI Model Configuration
+        </h2>
+
+        <p className="text-[var(--cream)]/70">
+          ABM.dev uses AI models for two key tasks during enrichment:
+        </p>
+
+        <div className="grid gap-4 sm:grid-cols-2 mb-6">
+          <div className="p-4 rounded-lg bg-[var(--dark-blue)]/50 border border-[var(--turquoise)]/20">
+            <Sparkles className="w-6 h-6 text-[var(--turquoise)] mb-2" />
+            <h3 className="font-medium text-[var(--cream)] mb-1">Writer Model</h3>
+            <p className="text-sm text-[var(--cream)]/60">
+              Synthesizes evidence from multiple sources into narrative fields like
+              summaries, highlights, and outreach angles.
+            </p>
+          </div>
+          <div className="p-4 rounded-lg bg-[var(--dark-blue)]/50 border border-[var(--turquoise)]/20">
+            <Shield className="w-6 h-6 text-[var(--turquoise)] mb-2" />
+            <h3 className="font-medium text-[var(--cream)] mb-1">Auditor Model</h3>
+            <p className="text-sm text-[var(--cream)]/60">
+              Reviews synthesized output for accuracy, consistency, and quality.
+              Catches hallucinations and improves reliability.
+            </p>
+          </div>
+        </div>
+
+        <h3 className="text-lg font-medium text-[var(--cream)]">Available Models</h3>
+
+        <div className="space-y-3">
+          {modelOptions.map((model) => (
+            <div
+              key={model.id}
+              className="p-4 rounded-lg bg-[var(--dark-blue)]/50 border border-[var(--turquoise)]/20"
+            >
+              <div className="flex items-start justify-between mb-2">
+                <div>
+                  <h4 className="font-medium text-[var(--cream)]">{model.name}</h4>
+                  <code className="text-xs text-[var(--cream)]/50">{model.id}</code>
+                </div>
+                <div className="flex items-center gap-2">
+                  <Badge
+                    variant="secondary"
+                    className="bg-[var(--turquoise)]/10 text-[var(--turquoise)] border-[var(--turquoise)]/20"
+                  >
+                    {model.role}
+                  </Badge>
+                  <span className="text-sm text-[var(--warning-yellow)]">{model.cost}</span>
+                </div>
+              </div>
+              <p className="text-sm text-[var(--cream)]/60">{model.description}</p>
+            </div>
+          ))}
+        </div>
+
+        <Callout type="tip" title="Model Selection Guidance">
+          <ul className="space-y-1 mt-2">
+            <li><strong>High volume:</strong> Sonnet writer + Haiku auditor (default)</li>
+            <li><strong>Premium quality:</strong> Opus writer + Sonnet auditor</li>
+            <li><strong>Cost optimization:</strong> Haiku writer + no auditor</li>
+          </ul>
+        </Callout>
+      </section>
+
+      {/* Source Configuration */}
+      <section className="space-y-4">
+        <h2 className="text-xl font-semibold text-[var(--cream)] flex items-center gap-2">
+          <Database className="w-5 h-5 text-[var(--turquoise)]" />
+          Source Configuration
+        </h2>
+
+        <p className="text-[var(--cream)]/70">
+          Control which data sources are queried during enrichment:
+        </p>
+
+        <CodeBlock
+          title="Source selection examples"
+          examples={{
+            javascript: `// Use only specific sources
+const result = await abmdev.enrich({
+  email: "jane@acme.com",
+  sources: ["linkedin", "hunter"]  // Skip Perplexity and Tavily
+});
+
+// Require LinkedIn (fail if unavailable)
+const result = await abmdev.enrich({
+  email: "jane@acme.com",
+  require_linkedin: true  // Returns error if LinkedIn fails
+});
+
+// Company enrichment with web sources only
+const result = await abmdev.enrich({
+  domain: "acme.com",
+  entity_type: "company",
+  sources: ["perplexity", "tavily"]  // Skip LinkedIn for companies
+});`,
+          }}
+        />
+
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-[var(--turquoise)]/20">
+                <th className="text-left py-3 pr-4 text-[var(--cream)]">Source</th>
+                <th className="text-left py-3 pr-4 text-[var(--cream)]">Best For</th>
+                <th className="text-left py-3 text-[var(--cream)]">Notes</th>
+              </tr>
+            </thead>
+            <tbody className="text-[var(--cream)]/70">
+              <tr className="border-b border-[var(--turquoise)]/10">
+                <td className="py-3 pr-4 font-medium text-[var(--cream)]">linkedin</td>
+                <td className="py-3 pr-4">Person enrichment</td>
+                <td className="py-3">Highest accuracy for job titles, history. Requires Browserbase.</td>
+              </tr>
+              <tr className="border-b border-[var(--turquoise)]/10">
+                <td className="py-3 pr-4 font-medium text-[var(--cream)]">hunter</td>
+                <td className="py-3 pr-4">Email verification</td>
+                <td className="py-3">Email deliverability, domain patterns. Included in all plans.</td>
+              </tr>
+              <tr className="border-b border-[var(--turquoise)]/10">
+                <td className="py-3 pr-4 font-medium text-[var(--cream)]">perplexity</td>
+                <td className="py-3 pr-4">Company research</td>
+                <td className="py-3">AI-powered research for company intel, news, funding.</td>
+              </tr>
+              <tr>
+                <td className="py-3 pr-4 font-medium text-[var(--cream)]">tavily</td>
+                <td className="py-3 pr-4">Web presence</td>
+                <td className="py-3">Web search aggregation, social profiles, press mentions.</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      {/* Confidence Thresholds */}
+      <section className="space-y-4">
+        <h2 className="text-xl font-semibold text-[var(--cream)] flex items-center gap-2">
+          <Gauge className="w-5 h-5 text-[var(--turquoise)]" />
+          Confidence Thresholds
+        </h2>
+
+        <p className="text-[var(--cream)]/70">
+          Use confidence thresholds to control enrichment quality gates:
+        </p>
+
+        <CodeBlock
+          title="Confidence-based automation"
+          examples={{
+            javascript: `// Conservative: high confidence required
+const result = await abmdev.enrich({
+  email: "jane@acme.com",
+  min_confidence_to_proceed: 0.85,  // Only proceed if 85%+ confident
+  auto_proceed: true                 // Auto-write to CRM
+});
+
+// Review workflow: medium threshold, manual approval
+const result = await abmdev.enrich({
+  email: "jane@acme.com",
+  min_confidence_to_proceed: 0.5,   // Accept moderate confidence
+  auto_proceed: false               // Require manual review
+});
+
+// Check result confidence
+if (result.metadata.confidence_score >= 0.9) {
+  console.log("High confidence - safe for automation");
+} else if (result.metadata.confidence_score >= 0.7) {
+  console.log("Good confidence - review recommended");
+} else {
+  console.log("Low confidence - manual verification needed");
+}`,
+          }}
+        />
+
+        <Callout type="warning" title="Threshold Recommendations">
+          <ul className="space-y-1 mt-2">
+            <li><strong>0.85+</strong>: Safe for automated CRM updates</li>
+            <li><strong>0.70+</strong>: Good for enrichment, consider review for critical fields</li>
+            <li><strong>0.50+</strong>: Display only, human verification required</li>
+            <li><strong>&lt;0.50</strong>: May indicate insufficient data sources</li>
+          </ul>
+        </Callout>
+      </section>
+
+      {/* Custom System Prompts */}
+      <section className="space-y-4">
+        <h2 className="text-xl font-semibold text-[var(--cream)]">Custom System Prompts</h2>
+
+        <p className="text-[var(--cream)]/70">
+          Customize the AI synthesis behavior with custom system prompts:
+        </p>
+
+        <CodeBlock
+          title="Custom prompts for different use cases"
+          examples={{
+            javascript: `// Sales-focused enrichment
+const salesResult = await abmdev.enrich({
+  email: "jane@acme.com",
+  person_system_prompt: \`You are enriching a B2B prospect for sales outreach.
+Focus on:
+- Buying signals and authority level
+- Technology stack and current solutions
+- Pain points relevant to our product
+- Recent company changes or initiatives
+Keep summaries action-oriented for sales reps.\`
+});
+
+// Marketing-focused enrichment
+const marketingResult = await abmdev.enrich({
+  domain: "acme.com",
+  entity_type: "company",
+  company_system_prompt: \`You are researching a company for marketing segmentation.
+Focus on:
+- Industry vertical and company size
+- Growth trajectory and funding status
+- Content topics and channels they engage with
+- Competitive landscape position
+Output should support personalized campaign targeting.\`
+});`,
+          }}
+        />
+
+        <Callout type="note" title="Prompt Best Practices">
+          <ul className="space-y-1 mt-2">
+            <li>Be specific about the use case and audience</li>
+            <li>List the key attributes you want emphasized</li>
+            <li>Specify output format preferences (concise, detailed, bullet points)</li>
+            <li>Include any domain-specific terminology to use or avoid</li>
+          </ul>
+        </Callout>
+      </section>
+
+      {/* Preflight Mode */}
+      <section className="space-y-4">
+        <h2 className="text-xl font-semibold text-[var(--cream)]">Preflight Mode</h2>
+
+        <p className="text-[var(--cream)]/70">
+          Test enrichment configuration without consuming credits:
+        </p>
+
+        <CodeBlock
+          title="Preflight check"
+          examples={{
+            javascript: `// Run preflight checks only
+const preflight = await abmdev.enrich({
+  email: "jane@acme.com",
+  preflight_only: true  // Don't execute, just validate
+});
+
+// Preflight returns:
+// - Source availability (which sources can provide data)
+// - Portfolio score (predicted enrichment quality)
+// - Estimated fields (what data will be populated)
+// - Configuration validation (any issues with your config)
+
+console.log(preflight.preflight);
+// {
+//   portfolio_score: 0.85,
+//   available_sources: ["linkedin", "hunter", "perplexity"],
+//   estimated_fields: 34,
+//   warnings: [],
+//   ready: true
+// }
+
+// If ready, proceed with actual enrichment
+if (preflight.preflight.ready) {
+  const result = await abmdev.enrich({
+    email: "jane@acme.com",
+    preflight_only: false
+  });
+}`,
+          }}
+        />
+      </section>
+
+      {/* Next steps */}
+      <section className="p-6 rounded-lg bg-[var(--turquoise)]/5 border border-[var(--turquoise)]/20">
+        <h2 className="text-lg font-semibold text-[var(--cream)] mb-4">Related Guides</h2>
+        <div className="grid gap-4 sm:grid-cols-2">
+          <Link
+            href="/docs/concepts/confidence-scores"
+            className="group flex items-center gap-3 p-4 rounded-lg bg-[var(--dark-blue)]/50 border border-[var(--turquoise)]/10 hover:border-[var(--turquoise)]/30 transition-colors"
+          >
+            <div>
+              <p className="font-medium text-[var(--cream)]">Confidence Scores</p>
+              <p className="text-sm text-[var(--cream)]/60">Understand quality metrics</p>
+            </div>
+            <ArrowRight className="w-4 h-4 text-[var(--turquoise)] ml-auto group-hover:translate-x-1 transition-transform" />
+          </Link>
+          <Link
+            href="/docs/concepts/data-sources"
+            className="group flex items-center gap-3 p-4 rounded-lg bg-[var(--dark-blue)]/50 border border-[var(--turquoise)]/10 hover:border-[var(--turquoise)]/30 transition-colors"
+          >
+            <div>
+              <p className="font-medium text-[var(--cream)]">Data Sources</p>
+              <p className="text-sm text-[var(--cream)]/60">Source capabilities</p>
+            </div>
+            <ArrowRight className="w-4 h-4 text-[var(--turquoise)] ml-auto group-hover:translate-x-1 transition-transform" />
+          </Link>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/app/docs/concepts/canonical-fields/page.tsx
+++ b/app/docs/concepts/canonical-fields/page.tsx
@@ -1,0 +1,293 @@
+import Link from "next/link";
+import { Badge } from "@/components/ui/badge";
+import { Callout } from "@/components/docs/Callout";
+import { FieldTable } from "@/components/docs/FieldTable";
+import {
+  Clock,
+  Database,
+  User,
+  Building2,
+  ArrowRight,
+  Layers
+} from "lucide-react";
+
+export const metadata = {
+  title: "Canonical Fields - ABM.dev Docs",
+  description: "Complete reference of all 90 enrichment fields available in ABM.dev",
+};
+
+// Person field categories
+const personFieldCategories = [
+  {
+    name: "Basic Info",
+    description: "Core identity fields",
+    fields: [
+      { name: "first_name", type: "string", description: "Person's first/given name", example: "Jane" },
+      { name: "last_name", type: "string", description: "Person's last/family name", example: "Smith" },
+      { name: "full_name", type: "string", description: "Complete name", example: "Jane Smith" },
+      { name: "title", type: "string", description: "Current job title", example: "VP of Engineering" },
+      { name: "normalized_title", type: "string", description: "Standardized job title for comparison", example: "Vice President Engineering" },
+    ]
+  },
+  {
+    name: "Contact",
+    description: "Communication channels",
+    fields: [
+      { name: "email", type: "string", description: "Primary email address", example: "jane@acme.com" },
+      { name: "email_status", type: "string", description: "Email verification status", example: "verified" },
+      { name: "email_confidence", type: "number", description: "Confidence score for email (0-100)", example: "95" },
+      { name: "phone_number", type: "string", description: "Primary phone number", example: "+1-555-0123" },
+      { name: "professional_profile_url", type: "string", description: "LinkedIn or similar profile URL", example: "linkedin.com/in/janesmith" },
+    ]
+  },
+  {
+    name: "Company Context",
+    description: "Organizational details",
+    fields: [
+      { name: "company", type: "string", description: "Current employer name", example: "Acme Corp" },
+      { name: "office_location", type: "string", description: "Work location/office", example: "San Francisco, CA" },
+      { name: "department", type: "string", description: "Department or team", example: "Engineering" },
+      { name: "seniority_level", type: "string", description: "Level in organization", example: "VP" },
+    ]
+  },
+  {
+    name: "Data Quality",
+    description: "Enrichment metadata",
+    fields: [
+      { name: "data_sources", type: "array", description: "Sources that provided data", example: '["linkedin", "hunter"]' },
+      { name: "source_count", type: "number", description: "Number of sources used", example: "3" },
+      { name: "last_verified_date", type: "date", description: "When data was last verified", example: "2024-01-15" },
+      { name: "verification_status", type: "string", description: "Overall verification state", example: "verified" },
+    ]
+  },
+  {
+    name: "Enriched Content",
+    description: "AI-generated insights",
+    fields: [
+      { name: "person_summary", type: "string", description: "Brief professional summary", example: "Engineering leader with 15 years..." },
+      { name: "background_highlights", type: "string", description: "Key career highlights", example: "Led 50-person team, scaled to IPO" },
+      { name: "recent_activity", type: "string", description: "Recent professional activity", example: "Speaking at SaaStr 2024" },
+      { name: "outreach_angle", type: "string", description: "Suggested outreach approach", example: "Mention their recent talk on..." },
+    ]
+  },
+  {
+    name: "AI-Generated",
+    description: "Machine learning outputs",
+    fields: [
+      { name: "matched_persona", type: "string", description: "Matched buyer persona", example: "Technical Decision Maker" },
+      { name: "persona_confidence_score", type: "number", description: "Confidence in persona match (0-100)", example: "87" },
+      { name: "persona_match_reason", type: "string", description: "Why this persona was matched", example: "Title and department align with..." },
+    ]
+  },
+];
+
+// Company field categories
+const companyFieldCategories = [
+  {
+    name: "Identity",
+    description: "Core company info",
+    fields: [
+      { name: "firm_name", type: "string", description: "Official company name", example: "Acme Corporation" },
+      { name: "website_url", type: "string", description: "Primary website", example: "https://acme.com" },
+      { name: "linkedin_company_page", type: "string", description: "LinkedIn company page URL", example: "linkedin.com/company/acme" },
+      { name: "logo_url", type: "string", description: "Company logo image URL", example: "https://acme.com/logo.png" },
+    ]
+  },
+  {
+    name: "Scale",
+    description: "Size and growth metrics",
+    fields: [
+      { name: "employees", type: "string", description: "Employee count or range", example: "500-1000" },
+      { name: "number_of_offices", type: "number", description: "Global office count", example: "12" },
+      { name: "number_of_clients", type: "string", description: "Customer base size", example: "500+" },
+      { name: "revenue", type: "string", description: "Annual revenue estimate", example: "$50M-$100M" },
+      { name: "founded_year", type: "number", description: "Year company was founded", example: "2015" },
+    ]
+  },
+  {
+    name: "Context",
+    description: "Industry and location",
+    fields: [
+      { name: "industry", type: "string", description: "Primary industry", example: "Enterprise Software" },
+      { name: "city", type: "string", description: "Headquarters city", example: "San Francisco" },
+      { name: "country_region", type: "string", description: "Country or region", example: "United States" },
+      { name: "description", type: "string", description: "Company description", example: "Leading provider of..." },
+    ]
+  },
+  {
+    name: "Finance",
+    description: "Financial and ownership",
+    fields: [
+      { name: "is_public", type: "boolean", description: "Whether publicly traded", example: "false" },
+      { name: "pe_backer", type: "string", description: "Private equity investor", example: "Sequoia Capital" },
+      { name: "pe_confidence", type: "number", description: "Confidence in PE data (0-100)", example: "85" },
+      { name: "parent_company", type: "string", description: "Parent organization if subsidiary", example: "Alphabet Inc" },
+      { name: "acquisitions", type: "array", description: "Companies acquired", example: '["StartupX", "TechY"]' },
+    ]
+  },
+  {
+    name: "Content",
+    description: "Company intelligence",
+    fields: [
+      { name: "services", type: "array", description: "Products and services offered", example: '["CRM", "Analytics"]' },
+      { name: "notable_highlights", type: "string", description: "Key achievements or news", example: "Recent Series C funding" },
+      { name: "recent_news", type: "string", description: "Latest company news", example: "Launched new AI feature" },
+      { name: "expansion_signals", type: "string", description: "Growth indicators", example: "Hiring 50+ engineers" },
+    ]
+  },
+  {
+    name: "AI-Generated",
+    description: "Machine learning outputs",
+    fields: [
+      { name: "icp_fit_score", type: "number", description: "Ideal Customer Profile fit (0-100)", example: "92" },
+      { name: "priority_tier", type: "string", description: "Account priority classification", example: "Tier 1" },
+      { name: "confidence_score", type: "number", description: "Overall data confidence (0-100)", example: "88" },
+    ]
+  },
+];
+
+export default function CanonicalFieldsPage() {
+  return (
+    <div className="space-y-12">
+      {/* Header */}
+      <div className="space-y-4">
+        <div className="flex items-center gap-2">
+          <Badge className="bg-[var(--turquoise)]/20 text-[var(--turquoise)] border-[var(--turquoise)]/30">
+            <Clock className="w-3 h-3 mr-1" />
+            10 min read
+          </Badge>
+          <Badge variant="secondary" className="bg-[var(--electric-blue)]/10 text-[var(--electric-blue)] border-[var(--electric-blue)]/30">
+            Reference
+          </Badge>
+        </div>
+        <h1 className="text-3xl lg:text-4xl font-serif text-[var(--cream)]">
+          Canonical Fields
+        </h1>
+        <p className="text-lg text-[var(--cream)]/70 max-w-2xl">
+          ABM.dev normalizes all enrichment data into a standard set of canonical fields.
+          This ensures consistency regardless of which data sources are used.
+        </p>
+      </div>
+
+      {/* Overview */}
+      <section className="space-y-4">
+        <h2 className="text-xl font-semibold text-[var(--cream)] flex items-center gap-2">
+          <Layers className="w-5 h-5 text-[var(--turquoise)]" />
+          What are Canonical Fields?
+        </h2>
+        <p className="text-[var(--cream)]/70">
+          Canonical fields are the standardized output format for all enrichment. When you enrich
+          a person or company, the data from multiple sources (LinkedIn, Hunter, Perplexity, etc.)
+          is normalized into these consistent field names.
+        </p>
+
+        <div className="grid gap-4 sm:grid-cols-2">
+          <div className="p-4 rounded-lg bg-[var(--dark-blue)]/50 border border-[var(--turquoise)]/20">
+            <User className="w-6 h-6 text-[var(--turquoise)] mb-2" />
+            <h3 className="font-medium text-[var(--cream)] mb-1">43 Person Fields</h3>
+            <p className="text-sm text-[var(--cream)]/60">
+              Contact info, job details, professional background, AI insights
+            </p>
+          </div>
+          <div className="p-4 rounded-lg bg-[var(--dark-blue)]/50 border border-[var(--turquoise)]/20">
+            <Building2 className="w-6 h-6 text-[var(--turquoise)] mb-2" />
+            <h3 className="font-medium text-[var(--cream)] mb-1">47 Company Fields</h3>
+            <p className="text-sm text-[var(--cream)]/60">
+              Company details, financials, growth signals, ICP scoring
+            </p>
+          </div>
+        </div>
+
+        <Callout type="tip" title="CRM Integration">
+          Canonical fields map directly to your CRM properties. See the{" "}
+          <Link href="/docs/concepts/field-mapping" className="text-[var(--turquoise)] hover:underline">
+            Field Mapping
+          </Link>{" "}
+          guide for details on how these sync to HubSpot, Salesforce, and other platforms.
+        </Callout>
+      </section>
+
+      {/* Person Fields */}
+      <section className="space-y-4">
+        <h2 className="text-xl font-semibold text-[var(--cream)] flex items-center gap-2">
+          <User className="w-5 h-5 text-[var(--turquoise)]" />
+          Person Fields
+        </h2>
+        <p className="text-[var(--cream)]/70">
+          Fields available when enriching a person/contact:
+        </p>
+        <FieldTable categories={personFieldCategories} entityType="person" />
+      </section>
+
+      {/* Company Fields */}
+      <section className="space-y-4">
+        <h2 className="text-xl font-semibold text-[var(--cream)] flex items-center gap-2">
+          <Building2 className="w-5 h-5 text-[var(--turquoise)]" />
+          Company Fields
+        </h2>
+        <p className="text-[var(--cream)]/70">
+          Fields available when enriching a company/organization:
+        </p>
+        <FieldTable categories={companyFieldCategories} entityType="company" />
+      </section>
+
+      {/* Field Categories */}
+      <section className="space-y-4">
+        <h2 className="text-xl font-semibold text-[var(--cream)]">Field Categories</h2>
+
+        <div className="space-y-3">
+          <div className="p-4 rounded-lg bg-[var(--dark-blue)]/50 border border-[var(--turquoise)]/20">
+            <h3 className="font-medium text-[var(--cream)] mb-2">Standard Fields</h3>
+            <p className="text-sm text-[var(--cream)]/70">
+              Core data like names, emails, and company info. These fields are populated
+              directly from source data with minimal transformation.
+            </p>
+          </div>
+
+          <div className="p-4 rounded-lg bg-[var(--dark-blue)]/50 border border-[var(--turquoise)]/20">
+            <h3 className="font-medium text-[var(--cream)] mb-2">Data Quality Fields</h3>
+            <p className="text-sm text-[var(--cream)]/70">
+              Metadata about the enrichment itself: which sources were used, when data
+              was verified, and confidence levels.
+            </p>
+          </div>
+
+          <div className="p-4 rounded-lg bg-[var(--turquoise)]/5 border border-[var(--turquoise)]/20">
+            <h3 className="font-medium text-[var(--cream)] mb-2">AI-Generated Fields</h3>
+            <p className="text-sm text-[var(--cream)]/70">
+              Synthesized insights created by our AI models: summaries, persona matching,
+              ICP fit scores, and outreach suggestions. These require AI synthesis to be enabled.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {/* Next steps */}
+      <section className="p-6 rounded-lg bg-[var(--turquoise)]/5 border border-[var(--turquoise)]/20">
+        <h2 className="text-lg font-semibold text-[var(--cream)] mb-4">Related Guides</h2>
+        <div className="grid gap-4 sm:grid-cols-2">
+          <Link
+            href="/docs/concepts/field-mapping"
+            className="group flex items-center gap-3 p-4 rounded-lg bg-[var(--dark-blue)]/50 border border-[var(--turquoise)]/10 hover:border-[var(--turquoise)]/30 transition-colors"
+          >
+            <div>
+              <p className="font-medium text-[var(--cream)]">Field Mapping</p>
+              <p className="text-sm text-[var(--cream)]/60">Map fields to your CRM</p>
+            </div>
+            <ArrowRight className="w-4 h-4 text-[var(--turquoise)] ml-auto group-hover:translate-x-1 transition-transform" />
+          </Link>
+          <Link
+            href="/docs/concepts/confidence-scores"
+            className="group flex items-center gap-3 p-4 rounded-lg bg-[var(--dark-blue)]/50 border border-[var(--turquoise)]/10 hover:border-[var(--turquoise)]/30 transition-colors"
+          >
+            <div>
+              <p className="font-medium text-[var(--cream)]">Confidence Scores</p>
+              <p className="text-sm text-[var(--cream)]/60">Understand data quality</p>
+            </div>
+            <ArrowRight className="w-4 h-4 text-[var(--turquoise)] ml-auto group-hover:translate-x-1 transition-transform" />
+          </Link>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/app/docs/concepts/confidence-scores/page.tsx
+++ b/app/docs/concepts/confidence-scores/page.tsx
@@ -1,0 +1,367 @@
+"use client";
+
+import Link from "next/link";
+import { Badge } from "@/components/ui/badge";
+import { Callout } from "@/components/docs/Callout";
+import { CodeBlock } from "@/components/docs/CodeBlock";
+import {
+  Clock,
+  TrendingUp,
+  CheckCircle2,
+  AlertTriangle,
+  ArrowRight,
+  Calculator,
+  Layers
+} from "lucide-react";
+
+export default function ConfidenceScoresPage() {
+  return (
+    <div className="space-y-12">
+      {/* Header */}
+      <div className="space-y-4">
+        <div className="flex items-center gap-2">
+          <Badge className="bg-[var(--turquoise)]/20 text-[var(--turquoise)] border-[var(--turquoise)]/30">
+            <Clock className="w-3 h-3 mr-1" />
+            8 min read
+          </Badge>
+        </div>
+        <h1 className="text-3xl lg:text-4xl font-serif text-[var(--cream)]">
+          Confidence Scores
+        </h1>
+        <p className="text-lg text-[var(--cream)]/70 max-w-2xl">
+          Every enriched field includes a confidence score (0-100) indicating how reliable
+          the data is. Use these scores to automate workflows and prioritize data quality.
+        </p>
+      </div>
+
+      {/* Overview */}
+      <section className="space-y-4">
+        <h2 className="text-xl font-semibold text-[var(--cream)] flex items-center gap-2">
+          <TrendingUp className="w-5 h-5 text-[var(--turquoise)]" />
+          Understanding Scores
+        </h2>
+
+        <div className="space-y-3">
+          <div className="flex items-center gap-4 p-4 rounded-lg bg-[var(--success-green)]/10 border border-[var(--success-green)]/30">
+            <div className="w-20 text-center">
+              <span className="text-2xl font-bold text-[var(--success-green)]">90-100</span>
+            </div>
+            <div>
+              <p className="font-medium text-[var(--cream)]">High Confidence</p>
+              <p className="text-sm text-[var(--cream)]/60">
+                Multiple sources agree. Safe for automated CRM updates and outreach workflows.
+                Typically 3+ sources with matching data.
+              </p>
+            </div>
+          </div>
+
+          <div className="flex items-center gap-4 p-4 rounded-lg bg-[var(--turquoise)]/10 border border-[var(--turquoise)]/30">
+            <div className="w-20 text-center">
+              <span className="text-2xl font-bold text-[var(--turquoise)]">70-89</span>
+            </div>
+            <div>
+              <p className="font-medium text-[var(--cream)]">Good Confidence</p>
+              <p className="text-sm text-[var(--cream)]/60">
+                Strong data with some uncertainty. Good for enrichment, consider review for
+                critical use cases. Typically 2+ sources with agreement.
+              </p>
+            </div>
+          </div>
+
+          <div className="flex items-center gap-4 p-4 rounded-lg bg-[var(--warning-yellow)]/10 border border-[var(--warning-yellow)]/30">
+            <div className="w-20 text-center">
+              <span className="text-2xl font-bold text-[var(--warning-yellow)]">50-69</span>
+            </div>
+            <div>
+              <p className="font-medium text-[var(--cream)]">Medium Confidence</p>
+              <p className="text-sm text-[var(--cream)]/60">
+                Limited source agreement or stale data. Recommended for display only,
+                with human verification before action.
+              </p>
+            </div>
+          </div>
+
+          <div className="flex items-center gap-4 p-4 rounded-lg bg-[var(--error-red)]/10 border border-[var(--error-red)]/30">
+            <div className="w-20 text-center">
+              <span className="text-2xl font-bold text-[var(--error-red)]">&lt;50</span>
+            </div>
+            <div>
+              <p className="font-medium text-[var(--cream)]">Low Confidence</p>
+              <p className="text-sm text-[var(--cream)]/60">
+                Single source or conflicting data. Manual verification required.
+                May be inferred or AI-generated without corroboration.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* How Calculated */}
+      <section className="space-y-4">
+        <h2 className="text-xl font-semibold text-[var(--cream)] flex items-center gap-2">
+          <Calculator className="w-5 h-5 text-[var(--turquoise)]" />
+          How Confidence is Calculated
+        </h2>
+
+        <p className="text-[var(--cream)]/70">
+          Confidence scores are computed using multiple factors:
+        </p>
+
+        <div className="grid gap-4 sm:grid-cols-2">
+          <div className="p-4 rounded-lg bg-[var(--dark-blue)]/50 border border-[var(--turquoise)]/20">
+            <h3 className="font-medium text-[var(--cream)] mb-2 flex items-center gap-2">
+              <Layers className="w-4 h-4 text-[var(--turquoise)]" />
+              Source Agreement
+            </h3>
+            <p className="text-sm text-[var(--cream)]/60">
+              When multiple sources return the same value for a field, confidence increases.
+              3 sources agreeing = ~95 confidence. 1 source = ~60-75 confidence.
+            </p>
+          </div>
+
+          <div className="p-4 rounded-lg bg-[var(--dark-blue)]/50 border border-[var(--turquoise)]/20">
+            <h3 className="font-medium text-[var(--cream)] mb-2 flex items-center gap-2">
+              <TrendingUp className="w-4 h-4 text-[var(--turquoise)]" />
+              Source Reliability
+            </h3>
+            <p className="text-sm text-[var(--cream)]/60">
+              Each source has historical accuracy ratings. LinkedIn data for job titles
+              scores higher than web-scraped data.
+            </p>
+          </div>
+
+          <div className="p-4 rounded-lg bg-[var(--dark-blue)]/50 border border-[var(--turquoise)]/20">
+            <h3 className="font-medium text-[var(--cream)] mb-2 flex items-center gap-2">
+              <Clock className="w-4 h-4 text-[var(--turquoise)]" />
+              Data Freshness
+            </h3>
+            <p className="text-sm text-[var(--cream)]/60">
+              Recently verified data scores higher. Data from 30 days ago = full score.
+              6+ months old = reduced confidence.
+            </p>
+          </div>
+
+          <div className="p-4 rounded-lg bg-[var(--dark-blue)]/50 border border-[var(--turquoise)]/20">
+            <h3 className="font-medium text-[var(--cream)] mb-2 flex items-center gap-2">
+              <CheckCircle2 className="w-4 h-4 text-[var(--turquoise)]" />
+              Cross-Validation
+            </h3>
+            <p className="text-sm text-[var(--cream)]/60">
+              Fields that validate each other increase confidence. Email domain matching
+              company domain = higher email confidence.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {/* Score Types */}
+      <section className="space-y-4">
+        <h2 className="text-xl font-semibold text-[var(--cream)]">Types of Confidence Scores</h2>
+
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-[var(--turquoise)]/20">
+                <th className="text-left py-3 pr-4 text-[var(--cream)]">Score Type</th>
+                <th className="text-left py-3 pr-4 text-[var(--cream)]">Scope</th>
+                <th className="text-left py-3 text-[var(--cream)]">Description</th>
+              </tr>
+            </thead>
+            <tbody className="text-[var(--cream)]/70">
+              <tr className="border-b border-[var(--turquoise)]/10">
+                <td className="py-3 pr-4 font-medium">
+                  <code className="text-xs px-1.5 py-0.5 rounded bg-[var(--turquoise)]/10 text-[var(--turquoise)]">
+                    confidence_score
+                  </code>
+                </td>
+                <td className="py-3 pr-4">Overall</td>
+                <td className="py-3">Average confidence across all enriched fields</td>
+              </tr>
+              <tr className="border-b border-[var(--turquoise)]/10">
+                <td className="py-3 pr-4 font-medium">
+                  <code className="text-xs px-1.5 py-0.5 rounded bg-[var(--turquoise)]/10 text-[var(--turquoise)]">
+                    email_confidence
+                  </code>
+                </td>
+                <td className="py-3 pr-4">Field-specific</td>
+                <td className="py-3">Confidence in email address accuracy and deliverability</td>
+              </tr>
+              <tr className="border-b border-[var(--turquoise)]/10">
+                <td className="py-3 pr-4 font-medium">
+                  <code className="text-xs px-1.5 py-0.5 rounded bg-[var(--turquoise)]/10 text-[var(--turquoise)]">
+                    persona_confidence_score
+                  </code>
+                </td>
+                <td className="py-3 pr-4">AI-generated</td>
+                <td className="py-3">Confidence in AI persona matching</td>
+              </tr>
+              <tr>
+                <td className="py-3 pr-4 font-medium">
+                  <code className="text-xs px-1.5 py-0.5 rounded bg-[var(--turquoise)]/10 text-[var(--turquoise)]">
+                    icp_fit_score
+                  </code>
+                </td>
+                <td className="py-3 pr-4">AI-generated</td>
+                <td className="py-3">How well a company matches your Ideal Customer Profile</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      {/* API Response */}
+      <section className="space-y-4">
+        <h2 className="text-xl font-semibold text-[var(--cream)]">Confidence in API Response</h2>
+
+        <p className="text-[var(--cream)]/70">
+          Enrichment responses include confidence data in multiple places:
+        </p>
+
+        <CodeBlock
+          title="Example response with confidence"
+          examples={{
+            javascript: `// Enrichment response structure
+{
+  "data": {
+    "person": {
+      "full_name": "Jane Smith",
+      "title": "VP of Engineering",
+      "email": "jane@acme.com"
+    }
+  },
+
+  // Per-field confidence scores
+  "confidence": {
+    "person.full_name": 95,
+    "person.title": 88,
+    "person.email": 92
+  },
+
+  // Overall metrics
+  "metadata": {
+    "confidence_score": 91,    // Average across all fields
+    "completeness_score": 85,  // % of fields populated
+    "success_rate": 100,       // % of sources that succeeded
+    "sources_used": ["linkedin", "hunter", "perplexity"]
+  }
+}`,
+          }}
+        />
+      </section>
+
+      {/* Using in Automations */}
+      <section className="space-y-4">
+        <h2 className="text-xl font-semibold text-[var(--cream)]">Using Confidence in Automations</h2>
+
+        <p className="text-[var(--cream)]/70">
+          Set confidence thresholds to control automatic data updates:
+        </p>
+
+        <CodeBlock
+          title="Conditional CRM update based on confidence"
+          examples={{
+            javascript: `// Only update CRM if confidence is high enough
+const enrichmentResult = await abmdev.enrich({
+  email: "jane@acme.com"
+});
+
+// Check overall confidence before CRM sync
+if (enrichmentResult.metadata.confidence_score >= 85) {
+  await hubspot.updateContact(contactId, enrichmentResult.data);
+  console.log("Contact updated automatically");
+} else {
+  // Queue for human review
+  await reviewQueue.add({
+    contact: enrichmentResult.data,
+    confidence: enrichmentResult.metadata.confidence_score,
+    reason: "Below confidence threshold"
+  });
+  console.log("Queued for review");
+}`,
+            python: `# Only update CRM if confidence is high enough
+result = abmdev.enrich(email="jane@acme.com")
+
+# Check overall confidence before CRM sync
+if result["metadata"]["confidence_score"] >= 85:
+    hubspot.update_contact(contact_id, result["data"])
+    print("Contact updated automatically")
+else:
+    # Queue for human review
+    review_queue.add({
+        "contact": result["data"],
+        "confidence": result["metadata"]["confidence_score"],
+        "reason": "Below confidence threshold"
+    })
+    print("Queued for review")`,
+          }}
+        />
+
+        <Callout type="tip" title="Recommended Thresholds">
+          <ul className="space-y-1 mt-2">
+            <li><strong>85+</strong>: Safe for automatic CRM updates</li>
+            <li><strong>75+</strong>: Good for enrichment display, review before action</li>
+            <li><strong>60+</strong>: Display only, human verification required</li>
+          </ul>
+        </Callout>
+      </section>
+
+      {/* Improving Confidence */}
+      <section className="space-y-4">
+        <h2 className="text-xl font-semibold text-[var(--cream)]">Improving Confidence Scores</h2>
+
+        <div className="space-y-3">
+          <div className="p-4 rounded-lg bg-[var(--dark-blue)]/50 border border-[var(--turquoise)]/20">
+            <h3 className="font-medium text-[var(--cream)] mb-2">Provide More Input Data</h3>
+            <p className="text-sm text-[var(--cream)]/70">
+              Include LinkedIn URLs, company domains, or full names in your requests.
+              More input = more sources can verify data = higher confidence.
+            </p>
+          </div>
+
+          <div className="p-4 rounded-lg bg-[var(--dark-blue)]/50 border border-[var(--turquoise)]/20">
+            <h3 className="font-medium text-[var(--cream)] mb-2">Enable More Sources</h3>
+            <p className="text-sm text-[var(--cream)]/70">
+              Connect LinkedIn via Browserbase for real-time profile data.
+              More sources means more cross-validation opportunities.
+            </p>
+          </div>
+
+          <div className="p-4 rounded-lg bg-[var(--dark-blue)]/50 border border-[var(--turquoise)]/20">
+            <h3 className="font-medium text-[var(--cream)] mb-2">Re-enrich Periodically</h3>
+            <p className="text-sm text-[var(--cream)]/70">
+              Data gets stale. Re-enriching contacts every 3-6 months maintains
+              high confidence by catching job changes and updates.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {/* Next steps */}
+      <section className="p-6 rounded-lg bg-[var(--turquoise)]/5 border border-[var(--turquoise)]/20">
+        <h2 className="text-lg font-semibold text-[var(--cream)] mb-4">Related Guides</h2>
+        <div className="grid gap-4 sm:grid-cols-2">
+          <Link
+            href="/docs/concepts/data-sources"
+            className="group flex items-center gap-3 p-4 rounded-lg bg-[var(--dark-blue)]/50 border border-[var(--turquoise)]/10 hover:border-[var(--turquoise)]/30 transition-colors"
+          >
+            <div>
+              <p className="font-medium text-[var(--cream)]">Data Sources</p>
+              <p className="text-sm text-[var(--cream)]/60">Learn about source reliability</p>
+            </div>
+            <ArrowRight className="w-4 h-4 text-[var(--turquoise)] ml-auto group-hover:translate-x-1 transition-transform" />
+          </Link>
+          <Link
+            href="/docs/advanced/enrichment-config"
+            className="group flex items-center gap-3 p-4 rounded-lg bg-[var(--dark-blue)]/50 border border-[var(--turquoise)]/10 hover:border-[var(--turquoise)]/30 transition-colors"
+          >
+            <div>
+              <p className="font-medium text-[var(--cream)]">Advanced Configuration</p>
+              <p className="text-sm text-[var(--cream)]/60">Set confidence thresholds</p>
+            </div>
+            <ArrowRight className="w-4 h-4 text-[var(--turquoise)] ml-auto group-hover:translate-x-1 transition-transform" />
+          </Link>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/app/docs/concepts/data-sources/page.tsx
+++ b/app/docs/concepts/data-sources/page.tsx
@@ -1,0 +1,340 @@
+import Link from "next/link";
+import { Badge } from "@/components/ui/badge";
+import { Callout } from "@/components/docs/Callout";
+import {
+  Clock,
+  Database,
+  Linkedin,
+  Mail,
+  Search,
+  Globe,
+  ArrowRight,
+  CheckCircle2,
+  Zap
+} from "lucide-react";
+
+export const metadata = {
+  title: "Data Sources - ABM.dev Docs",
+  description: "Learn about the data sources ABM.dev uses for enrichment",
+};
+
+const sources = [
+  {
+    name: "LinkedIn",
+    icon: <Linkedin className="w-6 h-6" />,
+    color: "#0A66C2",
+    method: "Browserbase",
+    dataType: "Profile data",
+    fields: [
+      "Current job title and company",
+      "Work history (last 5 positions)",
+      "Education history",
+      "Skills and endorsements",
+      "Profile photo URL",
+      "Recent activity and posts"
+    ],
+    confidence: "90-98",
+    freshness: "Real-time",
+    requirements: "LinkedIn connection via Browserbase"
+  },
+  {
+    name: "Hunter.io",
+    icon: <Mail className="w-6 h-6" />,
+    color: "#FF6B00",
+    method: "API",
+    dataType: "Email intelligence",
+    fields: [
+      "Email verification",
+      "Deliverability status",
+      "Email pattern detection",
+      "Domain search",
+      "Company email format"
+    ],
+    confidence: "85-95",
+    freshness: "Real-time",
+    requirements: "Included in all plans"
+  },
+  {
+    name: "Perplexity",
+    icon: <Search className="w-6 h-6" />,
+    color: "#20B2AA",
+    method: "AI Research",
+    dataType: "Company intelligence",
+    fields: [
+      "Company background",
+      "Recent news and announcements",
+      "Funding and financials",
+      "Products and services",
+      "Competitive landscape"
+    ],
+    confidence: "70-85",
+    freshness: "Near real-time",
+    requirements: "Included in all plans"
+  },
+  {
+    name: "Tavily",
+    icon: <Globe className="w-6 h-6" />,
+    color: "#6366F1",
+    method: "Web Search",
+    dataType: "Web presence",
+    fields: [
+      "Company website data",
+      "Social media presence",
+      "Press mentions",
+      "Industry associations",
+      "Public records"
+    ],
+    confidence: "65-80",
+    freshness: "Weekly crawls",
+    requirements: "Included in all plans"
+  }
+];
+
+export default function DataSourcesPage() {
+  return (
+    <div className="space-y-12">
+      {/* Header */}
+      <div className="space-y-4">
+        <div className="flex items-center gap-2">
+          <Badge className="bg-[var(--turquoise)]/20 text-[var(--turquoise)] border-[var(--turquoise)]/30">
+            <Clock className="w-3 h-3 mr-1" />
+            8 min read
+          </Badge>
+        </div>
+        <h1 className="text-3xl lg:text-4xl font-serif text-[var(--cream)]">
+          Data Sources
+        </h1>
+        <p className="text-lg text-[var(--cream)]/70 max-w-2xl">
+          ABM.dev aggregates data from multiple sources to provide comprehensive, accurate
+          enrichment. Each source has different strengths and confidence levels.
+        </p>
+      </div>
+
+      {/* How it works */}
+      <section className="space-y-4">
+        <h2 className="text-xl font-semibold text-[var(--cream)] flex items-center gap-2">
+          <Zap className="w-5 h-5 text-[var(--turquoise)]" />
+          Multi-Source Enrichment
+        </h2>
+
+        <p className="text-[var(--cream)]/70">
+          When you submit an enrichment request, ABM.dev queries multiple sources in parallel:
+        </p>
+
+        <div className="p-4 rounded-lg bg-[var(--dark-blue)]/50 border border-[var(--turquoise)]/20">
+          <ol className="space-y-3 text-[var(--cream)]/70">
+            <li className="flex gap-3">
+              <span className="flex-shrink-0 w-6 h-6 rounded-full bg-[var(--turquoise)] flex items-center justify-center text-[var(--dark-blue)] font-bold text-xs">1</span>
+              <span><strong className="text-[var(--cream)]">Source Portfolio Analysis</strong> — We evaluate which sources can provide data based on your input (email, domain, LinkedIn URL)</span>
+            </li>
+            <li className="flex gap-3">
+              <span className="flex-shrink-0 w-6 h-6 rounded-full bg-[var(--turquoise)] flex items-center justify-center text-[var(--dark-blue)] font-bold text-xs">2</span>
+              <span><strong className="text-[var(--cream)]">Parallel Fetching</strong> — All available sources are queried simultaneously for speed</span>
+            </li>
+            <li className="flex gap-3">
+              <span className="flex-shrink-0 w-6 h-6 rounded-full bg-[var(--turquoise)] flex items-center justify-center text-[var(--dark-blue)] font-bold text-xs">3</span>
+              <span><strong className="text-[var(--cream)]">Data Fusion</strong> — Results are merged, with conflicts resolved by source reliability and recency</span>
+            </li>
+            <li className="flex gap-3">
+              <span className="flex-shrink-0 w-6 h-6 rounded-full bg-[var(--turquoise)] flex items-center justify-center text-[var(--dark-blue)] font-bold text-xs">4</span>
+              <span><strong className="text-[var(--cream)]">AI Synthesis</strong> — Our AI generates summaries, insights, and persona matching from the merged evidence</span>
+            </li>
+          </ol>
+        </div>
+      </section>
+
+      {/* Source Cards */}
+      <section className="space-y-6">
+        <h2 className="text-xl font-semibold text-[var(--cream)] flex items-center gap-2">
+          <Database className="w-5 h-5 text-[var(--turquoise)]" />
+          Available Sources
+        </h2>
+
+        <div className="grid gap-6">
+          {sources.map((source) => (
+            <div
+              key={source.name}
+              className="p-6 rounded-lg bg-[var(--dark-blue)]/50 border border-[var(--turquoise)]/20"
+            >
+              <div className="flex items-start gap-4">
+                <div
+                  className="flex-shrink-0 w-12 h-12 rounded-lg flex items-center justify-center"
+                  style={{ backgroundColor: `${source.color}20`, color: source.color }}
+                >
+                  {source.icon}
+                </div>
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-3 mb-2">
+                    <h3 className="text-lg font-semibold text-[var(--cream)]">{source.name}</h3>
+                    <Badge variant="secondary" className="bg-[var(--turquoise)]/10 text-[var(--turquoise)] border-[var(--turquoise)]/20">
+                      {source.method}
+                    </Badge>
+                  </div>
+                  <p className="text-sm text-[var(--cream)]/60 mb-4">{source.dataType}</p>
+
+                  <div className="grid gap-4 sm:grid-cols-2">
+                    <div>
+                      <p className="text-xs font-medium text-[var(--cream)]/40 uppercase mb-2">Fields Provided</p>
+                      <ul className="space-y-1">
+                        {source.fields.map((field) => (
+                          <li key={field} className="flex items-center gap-2 text-sm text-[var(--cream)]/70">
+                            <CheckCircle2 className="w-3 h-3 text-[var(--turquoise)]" />
+                            {field}
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                    <div className="space-y-3">
+                      <div>
+                        <p className="text-xs font-medium text-[var(--cream)]/40 uppercase mb-1">Confidence Range</p>
+                        <p className="text-sm text-[var(--cream)]">{source.confidence}</p>
+                      </div>
+                      <div>
+                        <p className="text-xs font-medium text-[var(--cream)]/40 uppercase mb-1">Data Freshness</p>
+                        <p className="text-sm text-[var(--cream)]">{source.freshness}</p>
+                      </div>
+                      <div>
+                        <p className="text-xs font-medium text-[var(--cream)]/40 uppercase mb-1">Requirements</p>
+                        <p className="text-sm text-[var(--cream)]/70">{source.requirements}</p>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* Source Portfolio Tiers */}
+      <section className="space-y-4">
+        <h2 className="text-xl font-semibold text-[var(--cream)]">Source Portfolio Quality</h2>
+
+        <p className="text-[var(--cream)]/70">
+          Before enrichment begins, we analyze what sources can contribute based on your input:
+        </p>
+
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-[var(--turquoise)]/20">
+                <th className="text-left py-3 pr-4 text-[var(--cream)]">Tier</th>
+                <th className="text-left py-3 pr-4 text-[var(--cream)]">Score</th>
+                <th className="text-left py-3 text-[var(--cream)]">Description</th>
+              </tr>
+            </thead>
+            <tbody className="text-[var(--cream)]/70">
+              <tr className="border-b border-[var(--turquoise)]/10">
+                <td className="py-3 pr-4">
+                  <Badge className="bg-[var(--success-green)]/10 text-[var(--success-green)] border-[var(--success-green)]/30">
+                    Excellent
+                  </Badge>
+                </td>
+                <td className="py-3 pr-4">≥0.85</td>
+                <td className="py-3">All key sources available (LinkedIn + email + company)</td>
+              </tr>
+              <tr className="border-b border-[var(--turquoise)]/10">
+                <td className="py-3 pr-4">
+                  <Badge className="bg-[var(--turquoise)]/10 text-[var(--turquoise)] border-[var(--turquoise)]/30">
+                    Very Good
+                  </Badge>
+                </td>
+                <td className="py-3 pr-4">≥0.70</td>
+                <td className="py-3">Most sources available, high-quality enrichment expected</td>
+              </tr>
+              <tr className="border-b border-[var(--turquoise)]/10">
+                <td className="py-3 pr-4">
+                  <Badge className="bg-[var(--electric-blue)]/10 text-[var(--electric-blue)] border-[var(--electric-blue)]/30">
+                    Good
+                  </Badge>
+                </td>
+                <td className="py-3 pr-4">≥0.50</td>
+                <td className="py-3">Core sources available, solid enrichment</td>
+              </tr>
+              <tr className="border-b border-[var(--turquoise)]/10">
+                <td className="py-3 pr-4">
+                  <Badge className="bg-[var(--warning-yellow)]/10 text-[var(--warning-yellow)] border-[var(--warning-yellow)]/30">
+                    Moderate
+                  </Badge>
+                </td>
+                <td className="py-3 pr-4">≥0.30</td>
+                <td className="py-3">Limited sources, basic enrichment possible</td>
+              </tr>
+              <tr>
+                <td className="py-3 pr-4">
+                  <Badge className="bg-[var(--error-red)]/10 text-[var(--error-red)] border-[var(--error-red)]/30">
+                    Poor
+                  </Badge>
+                </td>
+                <td className="py-3 pr-4">&lt;0.30</td>
+                <td className="py-3">Insufficient data, enrichment may fail or be incomplete</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <Callout type="tip" title="Improve Your Portfolio Score">
+          Provide more input data to increase your portfolio score:
+          <ul className="mt-2 space-y-1">
+            <li>• Include LinkedIn profile URLs for person enrichment</li>
+            <li>• Provide company domain for company enrichment</li>
+            <li>• Connect LinkedIn via Browserbase for real-time access</li>
+          </ul>
+        </Callout>
+      </section>
+
+      {/* Source Selection */}
+      <section className="space-y-4">
+        <h2 className="text-xl font-semibold text-[var(--cream)]">Controlling Source Selection</h2>
+
+        <p className="text-[var(--cream)]/70">
+          You can control which sources are used in your enrichment requests:
+        </p>
+
+        <div className="p-4 rounded-lg bg-[var(--dark-blue)] border border-[var(--turquoise)]/20">
+          <pre className="text-sm text-[var(--cream)] overflow-x-auto">
+            <code>{`// Request with specific sources
+{
+  "email": "jane@acme.com",
+  "sources": ["linkedin", "hunter"],  // Only use these sources
+  "require_linkedin": true            // Fail if LinkedIn unavailable
+}
+
+// Request with all available sources (default)
+{
+  "email": "jane@acme.com"
+  // All enabled sources will be used
+}`}</code>
+          </pre>
+        </div>
+      </section>
+
+      {/* Next steps */}
+      <section className="p-6 rounded-lg bg-[var(--turquoise)]/5 border border-[var(--turquoise)]/20">
+        <h2 className="text-lg font-semibold text-[var(--cream)] mb-4">Related Guides</h2>
+        <div className="grid gap-4 sm:grid-cols-2">
+          <Link
+            href="/docs/guides/linkedin"
+            className="group flex items-center gap-3 p-4 rounded-lg bg-[var(--dark-blue)]/50 border border-[var(--turquoise)]/10 hover:border-[var(--turquoise)]/30 transition-colors"
+          >
+            <div>
+              <p className="font-medium text-[var(--cream)]">LinkedIn Integration</p>
+              <p className="text-sm text-[var(--cream)]/60">Connect via Browserbase</p>
+            </div>
+            <ArrowRight className="w-4 h-4 text-[var(--turquoise)] ml-auto group-hover:translate-x-1 transition-transform" />
+          </Link>
+          <Link
+            href="/docs/concepts/confidence-scores"
+            className="group flex items-center gap-3 p-4 rounded-lg bg-[var(--dark-blue)]/50 border border-[var(--turquoise)]/10 hover:border-[var(--turquoise)]/30 transition-colors"
+          >
+            <div>
+              <p className="font-medium text-[var(--cream)]">Confidence Scores</p>
+              <p className="text-sm text-[var(--cream)]/60">Understand source reliability</p>
+            </div>
+            <ArrowRight className="w-4 h-4 text-[var(--turquoise)] ml-auto group-hover:translate-x-1 transition-transform" />
+          </Link>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/app/docs/concepts/enrichment/page.tsx
+++ b/app/docs/concepts/enrichment/page.tsx
@@ -10,7 +10,11 @@ import {
   ArrowRight,
   Layers,
   Target,
-  RefreshCw
+  RefreshCw,
+  Sparkles,
+  Shield,
+  BarChart3,
+  Brain
 } from "lucide-react";
 
 export const metadata = {
@@ -26,14 +30,15 @@ export default function EnrichmentConceptPage() {
         <div className="flex items-center gap-2">
           <Badge className="bg-[var(--turquoise)]/20 text-[var(--turquoise)] border-[var(--turquoise)]/30">
             <Clock className="w-3 h-3 mr-1" />
-            8 min read
+            12 min read
           </Badge>
         </div>
         <h1 className="text-3xl lg:text-4xl font-serif text-[var(--cream)]">
           How Enrichment Works
         </h1>
         <p className="text-lg text-[var(--cream)]/70 max-w-2xl">
-          ABM.dev uses a multi-source enrichment engine that aggregates data from multiple providers to deliver accurate, confidence-scored results.
+          ABM.dev uses a sophisticated multi-source enrichment engine that gathers evidence from multiple providers,
+          synthesizes insights with AI, and delivers 90 standardized fields with confidence scores.
         </p>
       </div>
 
@@ -44,31 +49,38 @@ export default function EnrichmentConceptPage() {
           Overview
         </h2>
         <p className="text-[var(--cream)]/70">
-          When you submit an enrichment request, ABM.dev queries multiple data sources simultaneously,
-          normalizes the results, and returns a unified response with confidence scores indicating
-          how reliable each piece of data is.
+          When you submit an enrichment request, ABM.dev runs a sophisticated pipeline: analyzing source availability,
+          gathering evidence in parallel from multiple providers, synthesizing insights with AI, and outputting
+          90 standardized canonical fields with per-field confidence scores.
         </p>
 
-        <div className="grid gap-4 sm:grid-cols-3">
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
           <div className="p-4 rounded-lg bg-[var(--dark-blue)]/50 border border-[var(--turquoise)]/20">
             <Database className="w-6 h-6 text-[var(--turquoise)] mb-2" />
             <h3 className="font-medium text-[var(--cream)] mb-1">Multi-Source</h3>
             <p className="text-sm text-[var(--cream)]/60">
-              Data from 5+ providers for comprehensive coverage
+              4+ providers queried in parallel for comprehensive coverage
+            </p>
+          </div>
+          <div className="p-4 rounded-lg bg-[var(--dark-blue)]/50 border border-[var(--turquoise)]/20">
+            <Brain className="w-6 h-6 text-[var(--turquoise)] mb-2" />
+            <h3 className="font-medium text-[var(--cream)] mb-1">AI Synthesis</h3>
+            <p className="text-sm text-[var(--cream)]/60">
+              Intelligent merging with narrative generation and persona matching
             </p>
           </div>
           <div className="p-4 rounded-lg bg-[var(--dark-blue)]/50 border border-[var(--turquoise)]/20">
             <Target className="w-6 h-6 text-[var(--turquoise)] mb-2" />
-            <h3 className="font-medium text-[var(--cream)] mb-1">Confidence Scores</h3>
+            <h3 className="font-medium text-[var(--cream)] mb-1">90 Fields</h3>
             <p className="text-sm text-[var(--cream)]/60">
-              Every field includes a 0-1 confidence rating
+              Standardized canonical fields with per-field confidence
             </p>
           </div>
           <div className="p-4 rounded-lg bg-[var(--dark-blue)]/50 border border-[var(--turquoise)]/20">
             <RefreshCw className="w-6 h-6 text-[var(--turquoise)] mb-2" />
-            <h3 className="font-medium text-[var(--cream)] mb-1">Fresh Data</h3>
+            <h3 className="font-medium text-[var(--cream)] mb-1">CRM Sync</h3>
             <p className="text-sm text-[var(--cream)]/60">
-              Real-time fetching with freshness indicators
+              Automatic field mapping and writeback to HubSpot, Salesforce
             </p>
           </div>
         </div>
@@ -81,6 +93,10 @@ export default function EnrichmentConceptPage() {
           The Enrichment Pipeline
         </h2>
 
+        <p className="text-[var(--cream)]/70">
+          Every enrichment request flows through a 6-stage pipeline designed for maximum accuracy and efficiency:
+        </p>
+
         <div className="space-y-6">
           {/* Step 1 */}
           <div className="flex gap-4">
@@ -90,8 +106,9 @@ export default function EnrichmentConceptPage() {
             <div className="flex-1">
               <h3 className="font-medium text-[var(--cream)] mb-2">Input Normalization</h3>
               <p className="text-[var(--cream)]/70 text-sm mb-2">
-                Your input data (email, name, company) is normalized and validated.
-                Domain names are extracted from emails, and names are parsed into components.
+                Your input data (email, name, company, LinkedIn URL) is normalized and validated.
+                Domain names are extracted from emails, names are parsed into components, and
+                LinkedIn URLs are standardized.
               </p>
               <div className="p-3 rounded bg-[var(--dark-blue)] border border-[var(--turquoise)]/10">
                 <code className="text-sm text-[var(--cream)]">
@@ -107,21 +124,51 @@ export default function EnrichmentConceptPage() {
               2
             </div>
             <div className="flex-1">
-              <h3 className="font-medium text-[var(--cream)] mb-2">Parallel Data Fetching</h3>
+              <h3 className="font-medium text-[var(--cream)] mb-2">Source Portfolio Analysis</h3>
               <p className="text-[var(--cream)]/70 text-sm mb-2">
-                Multiple data sources are queried simultaneously to minimize latency.
-                Sources include LinkedIn, company databases, email verification services, and more.
+                Before querying any sources, we analyze which providers can contribute based on your input.
+                This produces a portfolio score predicting enrichment quality.
               </p>
-              <div className="flex flex-wrap gap-2">
-                {["LinkedIn", "Hunter.io", "Clearbit", "Apollo", "Custom Sources"].map((source) => (
-                  <Badge
-                    key={source}
-                    variant="secondary"
-                    className="bg-[var(--turquoise)]/10 text-[var(--turquoise)] border-[var(--turquoise)]/30"
-                  >
-                    {source}
-                  </Badge>
-                ))}
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b border-[var(--turquoise)]/20">
+                      <th className="text-left py-2 pr-4 text-[var(--cream)]">Tier</th>
+                      <th className="text-left py-2 pr-4 text-[var(--cream)]">Score</th>
+                      <th className="text-left py-2 text-[var(--cream)]">Meaning</th>
+                    </tr>
+                  </thead>
+                  <tbody className="text-[var(--cream)]/70">
+                    <tr className="border-b border-[var(--turquoise)]/10">
+                      <td className="py-2 pr-4">
+                        <Badge className="bg-[var(--success-green)]/10 text-[var(--success-green)]">Excellent</Badge>
+                      </td>
+                      <td className="py-2 pr-4">≥0.85</td>
+                      <td className="py-2">All key sources available (LinkedIn + email + company)</td>
+                    </tr>
+                    <tr className="border-b border-[var(--turquoise)]/10">
+                      <td className="py-2 pr-4">
+                        <Badge className="bg-[var(--turquoise)]/10 text-[var(--turquoise)]">Very Good</Badge>
+                      </td>
+                      <td className="py-2 pr-4">≥0.70</td>
+                      <td className="py-2">Most sources available, high-quality expected</td>
+                    </tr>
+                    <tr className="border-b border-[var(--turquoise)]/10">
+                      <td className="py-2 pr-4">
+                        <Badge className="bg-[var(--warning-yellow)]/10 text-[var(--warning-yellow)]">Moderate</Badge>
+                      </td>
+                      <td className="py-2 pr-4">≥0.50</td>
+                      <td className="py-2">Core sources available, solid enrichment</td>
+                    </tr>
+                    <tr>
+                      <td className="py-2 pr-4">
+                        <Badge className="bg-[var(--error-red)]/10 text-[var(--error-red)]">Poor</Badge>
+                      </td>
+                      <td className="py-2 pr-4">&lt;0.50</td>
+                      <td className="py-2">Limited sources, may need more input data</td>
+                    </tr>
+                  </tbody>
+                </table>
               </div>
             </div>
           </div>
@@ -132,11 +179,34 @@ export default function EnrichmentConceptPage() {
               3
             </div>
             <div className="flex-1">
-              <h3 className="font-medium text-[var(--cream)] mb-2">Data Fusion</h3>
-              <p className="text-[var(--cream)]/70 text-sm">
-                Results from all sources are merged using intelligent conflict resolution.
-                When sources disagree, we use historical accuracy, recency, and cross-validation
-                to determine the most likely correct value.
+              <h3 className="font-medium text-[var(--cream)] mb-2">Parallel Evidence Gathering</h3>
+              <p className="text-[var(--cream)]/70 text-sm mb-2">
+                All available sources are queried simultaneously to minimize latency.
+                Each source returns evidence with its own confidence level.
+              </p>
+              <div className="flex flex-wrap gap-2">
+                {[
+                  { name: "LinkedIn", color: "#0A66C2" },
+                  { name: "Hunter.io", color: "#FF6B00" },
+                  { name: "Perplexity", color: "#20B2AA" },
+                  { name: "Tavily", color: "#6366F1" },
+                ].map((source) => (
+                  <Badge
+                    key={source.name}
+                    variant="secondary"
+                    className="border"
+                    style={{
+                      backgroundColor: `${source.color}20`,
+                      color: source.color,
+                      borderColor: `${source.color}50`
+                    }}
+                  >
+                    {source.name}
+                  </Badge>
+                ))}
+              </div>
+              <p className="text-[var(--cream)]/50 text-xs mt-2">
+                See <Link href="/docs/concepts/data-sources" className="text-[var(--turquoise)] hover:underline">Data Sources</Link> for details on each provider.
               </p>
             </div>
           </div>
@@ -147,28 +217,85 @@ export default function EnrichmentConceptPage() {
               4
             </div>
             <div className="flex-1">
-              <h3 className="font-medium text-[var(--cream)] mb-2">Confidence Scoring</h3>
-              <p className="text-[var(--cream)]/70 text-sm">
-                Each field receives a confidence score from 0 to 1, calculated based on:
+              <h3 className="font-medium text-[var(--cream)] mb-2">AI Synthesis</h3>
+              <p className="text-[var(--cream)]/70 text-sm mb-2">
+                Evidence from all sources is merged using AI models that resolve conflicts,
+                generate narrative fields, and match buyer personas. This stage:
               </p>
-              <ul className="mt-2 space-y-1 text-sm text-[var(--cream)]/70">
+              <ul className="space-y-1 text-sm text-[var(--cream)]/70">
                 <li className="flex items-center gap-2">
                   <CheckCircle2 className="w-4 h-4 text-[var(--turquoise)]" />
-                  Number of sources that agree
+                  Resolves conflicting data using source reliability and recency
                 </li>
                 <li className="flex items-center gap-2">
                   <CheckCircle2 className="w-4 h-4 text-[var(--turquoise)]" />
-                  Historical accuracy of each source
+                  Generates summaries, highlights, and outreach angles
                 </li>
                 <li className="flex items-center gap-2">
                   <CheckCircle2 className="w-4 h-4 text-[var(--turquoise)]" />
-                  Recency of the data
+                  Matches against your buyer personas with confidence scoring
                 </li>
                 <li className="flex items-center gap-2">
                   <CheckCircle2 className="w-4 h-4 text-[var(--turquoise)]" />
-                  Cross-field validation
+                  Calculates ICP fit scores for companies
                 </li>
               </ul>
+              <Callout type="tip" title="AI Models">
+                By default, synthesis uses Claude Sonnet for generation and Claude Haiku for auditing.
+                See <Link href="/docs/advanced/enrichment-config" className="text-[var(--turquoise)] hover:underline">Advanced Configuration</Link> to customize models.
+              </Callout>
+            </div>
+          </div>
+
+          {/* Step 5 */}
+          <div className="flex gap-4">
+            <div className="flex-shrink-0 w-8 h-8 rounded-full bg-[var(--turquoise)] flex items-center justify-center text-[var(--dark-blue)] font-bold text-sm">
+              5
+            </div>
+            <div className="flex-1">
+              <h3 className="font-medium text-[var(--cream)] mb-2">Projection & Validation</h3>
+              <p className="text-[var(--cream)]/70 text-sm mb-2">
+                Synthesized data is projected into 90 canonical fields. Each field receives:
+              </p>
+              <ul className="space-y-1 text-sm text-[var(--cream)]/70">
+                <li className="flex items-center gap-2">
+                  <CheckCircle2 className="w-4 h-4 text-[var(--turquoise)]" />
+                  <strong className="text-[var(--cream)]">Confidence score (0-100)</strong> — how reliable is this value?
+                </li>
+                <li className="flex items-center gap-2">
+                  <CheckCircle2 className="w-4 h-4 text-[var(--turquoise)]" />
+                  <strong className="text-[var(--cream)]">Source attribution</strong> — which sources contributed?
+                </li>
+                <li className="flex items-center gap-2">
+                  <CheckCircle2 className="w-4 h-4 text-[var(--turquoise)]" />
+                  <strong className="text-[var(--cream)]">Freshness timestamp</strong> — when was data last verified?
+                </li>
+              </ul>
+              <p className="text-[var(--cream)]/50 text-xs mt-2">
+                See <Link href="/docs/concepts/canonical-fields" className="text-[var(--turquoise)] hover:underline">Canonical Fields</Link> for the complete field reference.
+              </p>
+            </div>
+          </div>
+
+          {/* Step 6 */}
+          <div className="flex gap-4">
+            <div className="flex-shrink-0 w-8 h-8 rounded-full bg-[var(--turquoise)] flex items-center justify-center text-[var(--dark-blue)] font-bold text-sm">
+              6
+            </div>
+            <div className="flex-1">
+              <h3 className="font-medium text-[var(--cream)] mb-2">Field Mapping & Writeback</h3>
+              <p className="text-[var(--cream)]/70 text-sm mb-2">
+                If CRM integration is enabled, canonical fields are transformed and written to your CRM
+                using configurable field mappings. Transformations can format, concat, split, or convert values.
+              </p>
+              <div className="p-3 rounded bg-[var(--dark-blue)] border border-[var(--turquoise)]/10">
+                <code className="text-sm text-[var(--cream)]">
+                  canonical: title → hubspot: jobtitle → &quot;VP of Engineering&quot;
+                </code>
+              </div>
+              <p className="text-[var(--cream)]/50 text-xs mt-2">
+                See <Link href="/docs/concepts/field-mapping" className="text-[var(--turquoise)] hover:underline">Field Mapping</Link> for transformation options.
+              </p>
             </div>
           </div>
         </div>
@@ -280,22 +407,42 @@ export default function EnrichmentConceptPage() {
         <h2 className="text-lg font-semibold text-[var(--cream)] mb-4">Continue Learning</h2>
         <div className="grid gap-4 sm:grid-cols-2">
           <Link
-            href="/docs/concepts/authentication"
+            href="/docs/concepts/canonical-fields"
             className="group flex items-center gap-3 p-4 rounded-lg bg-[var(--dark-blue)]/50 border border-[var(--turquoise)]/10 hover:border-[var(--turquoise)]/30 transition-colors"
           >
             <div>
-              <p className="font-medium text-[var(--cream)]">Authentication</p>
-              <p className="text-sm text-[var(--cream)]/60">Learn about API keys & JWT tokens</p>
+              <p className="font-medium text-[var(--cream)]">Canonical Fields</p>
+              <p className="text-sm text-[var(--cream)]/60">All 90 enrichment fields reference</p>
             </div>
             <ArrowRight className="w-4 h-4 text-[var(--turquoise)] ml-auto group-hover:translate-x-1 transition-transform" />
           </Link>
           <Link
-            href="/api-reference"
+            href="/docs/concepts/confidence-scores"
             className="group flex items-center gap-3 p-4 rounded-lg bg-[var(--dark-blue)]/50 border border-[var(--turquoise)]/10 hover:border-[var(--turquoise)]/30 transition-colors"
           >
             <div>
-              <p className="font-medium text-[var(--cream)]">API Reference</p>
-              <p className="text-sm text-[var(--cream)]/60">Full API documentation</p>
+              <p className="font-medium text-[var(--cream)]">Confidence Scores</p>
+              <p className="text-sm text-[var(--cream)]/60">Understanding data quality metrics</p>
+            </div>
+            <ArrowRight className="w-4 h-4 text-[var(--turquoise)] ml-auto group-hover:translate-x-1 transition-transform" />
+          </Link>
+          <Link
+            href="/docs/concepts/data-sources"
+            className="group flex items-center gap-3 p-4 rounded-lg bg-[var(--dark-blue)]/50 border border-[var(--turquoise)]/10 hover:border-[var(--turquoise)]/30 transition-colors"
+          >
+            <div>
+              <p className="font-medium text-[var(--cream)]">Data Sources</p>
+              <p className="text-sm text-[var(--cream)]/60">Where enrichment data comes from</p>
+            </div>
+            <ArrowRight className="w-4 h-4 text-[var(--turquoise)] ml-auto group-hover:translate-x-1 transition-transform" />
+          </Link>
+          <Link
+            href="/docs/advanced/enrichment-config"
+            className="group flex items-center gap-3 p-4 rounded-lg bg-[var(--dark-blue)]/50 border border-[var(--turquoise)]/10 hover:border-[var(--turquoise)]/30 transition-colors"
+          >
+            <div>
+              <p className="font-medium text-[var(--cream)]">Advanced Configuration</p>
+              <p className="text-sm text-[var(--cream)]/60">Fine-tune models, sources & thresholds</p>
             </div>
             <ArrowRight className="w-4 h-4 text-[var(--turquoise)] ml-auto group-hover:translate-x-1 transition-transform" />
           </Link>

--- a/app/docs/concepts/field-mapping/page.tsx
+++ b/app/docs/concepts/field-mapping/page.tsx
@@ -1,0 +1,413 @@
+import Link from "next/link";
+import { Badge } from "@/components/ui/badge";
+import { Callout } from "@/components/docs/Callout";
+import { CodeBlock } from "@/components/docs/CodeBlock";
+import {
+  Clock,
+  ArrowLeftRight,
+  Database,
+  RefreshCw,
+  ArrowRight,
+  Settings2,
+  Layers,
+  Zap
+} from "lucide-react";
+
+export const metadata = {
+  title: "Field Mapping - ABM.dev Docs",
+  description: "Learn how ABM.dev maps enriched data to your CRM fields",
+};
+
+const transformationTypes = [
+  {
+    name: "DateFormat",
+    description: "Parse and format dates between systems",
+    example: "2024-01-15 → Jan 15, 2024",
+  },
+  {
+    name: "Concat",
+    description: "Combine multiple fields into one",
+    example: "first_name + last_name → full_name",
+  },
+  {
+    name: "Split",
+    description: "Decompose a field into multiple values",
+    example: "San Francisco, CA → city: San Francisco, state: CA",
+  },
+  {
+    name: "Format",
+    description: "Pattern-based string formatting",
+    example: "+1-555-0123 → (555) 012-3123",
+  },
+  {
+    name: "Uppercase/Lowercase",
+    description: "Case conversion for consistency",
+    example: "engineering → ENGINEERING",
+  },
+  {
+    name: "Trim",
+    description: "Remove leading/trailing whitespace",
+    example: "  Jane Smith  → Jane Smith",
+  },
+];
+
+const defaultMappings = {
+  person: [
+    { canonical: "email", hubspot: "email", salesforce: "Email" },
+    { canonical: "first_name", hubspot: "firstname", salesforce: "FirstName" },
+    { canonical: "last_name", hubspot: "lastname", salesforce: "LastName" },
+    { canonical: "title", hubspot: "jobtitle", salesforce: "Title" },
+    { canonical: "company", hubspot: "company", salesforce: "Company" },
+    { canonical: "phone_number", hubspot: "phone", salesforce: "Phone" },
+    { canonical: "professional_profile_url", hubspot: "linkedin_url", salesforce: "LinkedIn_URL__c" },
+    { canonical: "office_location", hubspot: "city", salesforce: "MailingCity" },
+  ],
+  company: [
+    { canonical: "firm_name", hubspot: "name", salesforce: "Name" },
+    { canonical: "website_url", hubspot: "website", salesforce: "Website" },
+    { canonical: "industry", hubspot: "industry", salesforce: "Industry" },
+    { canonical: "employees", hubspot: "numberofemployees", salesforce: "NumberOfEmployees" },
+    { canonical: "city", hubspot: "city", salesforce: "BillingCity" },
+    { canonical: "country_region", hubspot: "country", salesforce: "BillingCountry" },
+    { canonical: "description", hubspot: "description", salesforce: "Description" },
+    { canonical: "revenue", hubspot: "annualrevenue", salesforce: "AnnualRevenue" },
+  ],
+};
+
+export default function FieldMappingPage() {
+  return (
+    <div className="space-y-12">
+      {/* Header */}
+      <div className="space-y-4">
+        <div className="flex items-center gap-2">
+          <Badge className="bg-[var(--turquoise)]/20 text-[var(--turquoise)] border-[var(--turquoise)]/30">
+            <Clock className="w-3 h-3 mr-1" />
+            10 min read
+          </Badge>
+        </div>
+        <h1 className="text-3xl lg:text-4xl font-serif text-[var(--cream)]">
+          Field Mapping
+        </h1>
+        <p className="text-lg text-[var(--cream)]/70 max-w-2xl">
+          ABM.dev maps enriched data from canonical fields to your CRM&apos;s native properties.
+          Customize mappings and transformations to match your data model.
+        </p>
+      </div>
+
+      {/* How it works */}
+      <section className="space-y-4">
+        <h2 className="text-xl font-semibold text-[var(--cream)] flex items-center gap-2">
+          <ArrowLeftRight className="w-5 h-5 text-[var(--turquoise)]" />
+          How Field Mapping Works
+        </h2>
+
+        <p className="text-[var(--cream)]/70">
+          When enrichment completes, ABM.dev translates the standardized canonical fields into
+          your CRM&apos;s property format:
+        </p>
+
+        <div className="p-4 rounded-lg bg-[var(--dark-blue)]/50 border border-[var(--turquoise)]/20">
+          <div className="flex flex-col sm:flex-row items-center justify-center gap-4 text-center">
+            <div className="p-3 rounded-lg bg-[var(--turquoise)]/10 border border-[var(--turquoise)]/30">
+              <Database className="w-6 h-6 text-[var(--turquoise)] mx-auto mb-1" />
+              <span className="text-sm text-[var(--cream)]">Canonical Fields</span>
+              <p className="text-xs text-[var(--cream)]/50">90 standardized fields</p>
+            </div>
+            <ArrowRight className="w-6 h-6 text-[var(--turquoise)] rotate-90 sm:rotate-0" />
+            <div className="p-3 rounded-lg bg-[var(--electric-blue)]/10 border border-[var(--electric-blue)]/30">
+              <Settings2 className="w-6 h-6 text-[var(--electric-blue)] mx-auto mb-1" />
+              <span className="text-sm text-[var(--cream)]">Transformations</span>
+              <p className="text-xs text-[var(--cream)]/50">Format, concat, split</p>
+            </div>
+            <ArrowRight className="w-6 h-6 text-[var(--turquoise)] rotate-90 sm:rotate-0" />
+            <div className="p-3 rounded-lg bg-[var(--success-green)]/10 border border-[var(--success-green)]/30">
+              <RefreshCw className="w-6 h-6 text-[var(--success-green)] mx-auto mb-1" />
+              <span className="text-sm text-[var(--cream)]">CRM Properties</span>
+              <p className="text-xs text-[var(--cream)]/50">HubSpot, Salesforce, etc.</p>
+            </div>
+          </div>
+        </div>
+
+        <Callout type="tip" title="Bidirectional Sync">
+          Field mappings work in both directions. When you enrich from a CRM contact,
+          we read existing data using the same mappings to provide context for enrichment.
+        </Callout>
+      </section>
+
+      {/* Default Mappings */}
+      <section className="space-y-4">
+        <h2 className="text-xl font-semibold text-[var(--cream)] flex items-center gap-2">
+          <Layers className="w-5 h-5 text-[var(--turquoise)]" />
+          Default Mappings
+        </h2>
+
+        <p className="text-[var(--cream)]/70">
+          ABM.dev includes sensible defaults for common CRM platforms. These work out of the box
+          with no configuration required.
+        </p>
+
+        {/* Person Mappings Table */}
+        <div className="space-y-2">
+          <h3 className="text-lg font-medium text-[var(--cream)]">Person/Contact Fields</h3>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-[var(--turquoise)]/20">
+                  <th className="text-left py-3 pr-4 text-[var(--cream)]">Canonical Field</th>
+                  <th className="text-left py-3 pr-4 text-[var(--cream)]">HubSpot</th>
+                  <th className="text-left py-3 text-[var(--cream)]">Salesforce</th>
+                </tr>
+              </thead>
+              <tbody className="text-[var(--cream)]/70">
+                {defaultMappings.person.map((mapping) => (
+                  <tr key={mapping.canonical} className="border-b border-[var(--turquoise)]/10">
+                    <td className="py-2 pr-4">
+                      <code className="text-xs px-1.5 py-0.5 rounded bg-[var(--turquoise)]/10 text-[var(--turquoise)]">
+                        {mapping.canonical}
+                      </code>
+                    </td>
+                    <td className="py-2 pr-4 font-mono text-xs">{mapping.hubspot}</td>
+                    <td className="py-2 font-mono text-xs">{mapping.salesforce}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        {/* Company Mappings Table */}
+        <div className="space-y-2">
+          <h3 className="text-lg font-medium text-[var(--cream)]">Company/Account Fields</h3>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-[var(--turquoise)]/20">
+                  <th className="text-left py-3 pr-4 text-[var(--cream)]">Canonical Field</th>
+                  <th className="text-left py-3 pr-4 text-[var(--cream)]">HubSpot</th>
+                  <th className="text-left py-3 text-[var(--cream)]">Salesforce</th>
+                </tr>
+              </thead>
+              <tbody className="text-[var(--cream)]/70">
+                {defaultMappings.company.map((mapping) => (
+                  <tr key={mapping.canonical} className="border-b border-[var(--turquoise)]/10">
+                    <td className="py-2 pr-4">
+                      <code className="text-xs px-1.5 py-0.5 rounded bg-[var(--turquoise)]/10 text-[var(--turquoise)]">
+                        {mapping.canonical}
+                      </code>
+                    </td>
+                    <td className="py-2 pr-4 font-mono text-xs">{mapping.hubspot}</td>
+                    <td className="py-2 font-mono text-xs">{mapping.salesforce}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </section>
+
+      {/* Transformations */}
+      <section className="space-y-4">
+        <h2 className="text-xl font-semibold text-[var(--cream)] flex items-center gap-2">
+          <Zap className="w-5 h-5 text-[var(--turquoise)]" />
+          Transformations
+        </h2>
+
+        <p className="text-[var(--cream)]/70">
+          When canonical field values need to be modified before writing to your CRM,
+          transformations handle the conversion:
+        </p>
+
+        <div className="grid gap-3 sm:grid-cols-2">
+          {transformationTypes.map((transform) => (
+            <div
+              key={transform.name}
+              className="p-4 rounded-lg bg-[var(--dark-blue)]/50 border border-[var(--turquoise)]/20"
+            >
+              <h3 className="font-medium text-[var(--cream)] mb-1">{transform.name}</h3>
+              <p className="text-sm text-[var(--cream)]/60 mb-2">{transform.description}</p>
+              <code className="text-xs px-2 py-1 rounded bg-[var(--turquoise)]/10 text-[var(--turquoise)]">
+                {transform.example}
+              </code>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* Custom Mappings */}
+      <section className="space-y-4">
+        <h2 className="text-xl font-semibold text-[var(--cream)]">Custom Field Mappings</h2>
+
+        <p className="text-[var(--cream)]/70">
+          Override default mappings or add custom fields via the API:
+        </p>
+
+        <CodeBlock
+          title="Setting custom field mappings"
+          examples={{
+            javascript: `// Configure custom mappings for your organization
+const mappings = await abmdev.fieldMappings.create({
+  integration_type: "hubspot",
+  entity_type: "person",
+  mappings: [
+    {
+      internal_field: "matched_persona",    // Canonical field
+      external_field: "abm_persona",        // Your HubSpot property
+      direction: "write",                   // write, read, or bidirectional
+      transformation: null                  // Optional transformation
+    },
+    {
+      internal_field: "confidence_score",
+      external_field: "abm_confidence",
+      direction: "write",
+      transformation: {
+        type: "format",
+        pattern: "{value}%"                 // 85 → "85%"
+      }
+    },
+    {
+      internal_field: "full_name",
+      external_field: "contact_name",
+      direction: "bidirectional",
+      transformation: {
+        type: "uppercase"                   // Jane Smith → JANE SMITH
+      }
+    }
+  ]
+});`,
+            python: `# Configure custom mappings for your organization
+mappings = abmdev.field_mappings.create(
+    integration_type="hubspot",
+    entity_type="person",
+    mappings=[
+        {
+            "internal_field": "matched_persona",    # Canonical field
+            "external_field": "abm_persona",        # Your HubSpot property
+            "direction": "write",                   # write, read, or bidirectional
+            "transformation": None                  # Optional transformation
+        },
+        {
+            "internal_field": "confidence_score",
+            "external_field": "abm_confidence",
+            "direction": "write",
+            "transformation": {
+                "type": "format",
+                "pattern": "{value}%"               # 85 → "85%"
+            }
+        },
+        {
+            "internal_field": "full_name",
+            "external_field": "contact_name",
+            "direction": "bidirectional",
+            "transformation": {
+                "type": "uppercase"                 # Jane Smith → JANE SMITH
+            }
+        }
+    ]
+)`,
+          }}
+        />
+      </section>
+
+      {/* Mapping Direction */}
+      <section className="space-y-4">
+        <h2 className="text-xl font-semibold text-[var(--cream)]">Mapping Directions</h2>
+
+        <div className="space-y-3">
+          <div className="p-4 rounded-lg bg-[var(--dark-blue)]/50 border border-[var(--turquoise)]/20">
+            <h3 className="font-medium text-[var(--cream)] mb-2">Write (ABM.dev → CRM)</h3>
+            <p className="text-sm text-[var(--cream)]/70">
+              Enriched data flows from ABM.dev to your CRM. Use this for fields you want to
+              populate or update in your CRM after enrichment.
+            </p>
+          </div>
+
+          <div className="p-4 rounded-lg bg-[var(--dark-blue)]/50 border border-[var(--turquoise)]/20">
+            <h3 className="font-medium text-[var(--cream)] mb-2">Read (CRM → ABM.dev)</h3>
+            <p className="text-sm text-[var(--cream)]/70">
+              Existing CRM data is read into ABM.dev to provide context during enrichment.
+              Useful for using CRM data as enrichment input.
+            </p>
+          </div>
+
+          <div className="p-4 rounded-lg bg-[var(--turquoise)]/5 border border-[var(--turquoise)]/20">
+            <h3 className="font-medium text-[var(--cream)] mb-2">Bidirectional</h3>
+            <p className="text-sm text-[var(--cream)]/70">
+              Data flows both ways. CRM data is read for context, and enriched data is
+              written back. This is the most common configuration for core fields.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {/* Fallback Priority */}
+      <section className="space-y-4">
+        <h2 className="text-xl font-semibold text-[var(--cream)]">Fallback Priority</h2>
+
+        <p className="text-[var(--cream)]/70">
+          When multiple canonical fields could map to the same CRM property, use priority
+          to control which takes precedence:
+        </p>
+
+        <CodeBlock
+          title="Priority-based fallback"
+          examples={{
+            javascript: `// Map multiple fields to one CRM property with fallback
+const mappings = await abmdev.fieldMappings.create({
+  integration_type: "hubspot",
+  entity_type: "person",
+  mappings: [
+    {
+      internal_field: "email",
+      external_field: "email",
+      direction: "write",
+      priority: 1                    // Highest priority
+    },
+    {
+      internal_field: "secondary_email",
+      external_field: "email",
+      direction: "write",
+      priority: 2                    // Used if primary is empty
+    }
+  ]
+});
+
+// ABM.dev will try fields in priority order
+// If email is empty, secondary_email is used`,
+          }}
+        />
+
+        <Callout type="note" title="Priority Rules">
+          Lower numbers = higher priority. If a high-priority field has data, lower-priority
+          mappings to the same CRM field are skipped.
+        </Callout>
+      </section>
+
+      {/* Next steps */}
+      <section className="p-6 rounded-lg bg-[var(--turquoise)]/5 border border-[var(--turquoise)]/20">
+        <h2 className="text-lg font-semibold text-[var(--cream)] mb-4">Related Guides</h2>
+        <div className="grid gap-4 sm:grid-cols-2">
+          <Link
+            href="/docs/concepts/canonical-fields"
+            className="group flex items-center gap-3 p-4 rounded-lg bg-[var(--dark-blue)]/50 border border-[var(--turquoise)]/10 hover:border-[var(--turquoise)]/30 transition-colors"
+          >
+            <div>
+              <p className="font-medium text-[var(--cream)]">Canonical Fields</p>
+              <p className="text-sm text-[var(--cream)]/60">All 90 enrichment fields</p>
+            </div>
+            <ArrowRight className="w-4 h-4 text-[var(--turquoise)] ml-auto group-hover:translate-x-1 transition-transform" />
+          </Link>
+          <Link
+            href="/docs/guides/hubspot"
+            className="group flex items-center gap-3 p-4 rounded-lg bg-[var(--dark-blue)]/50 border border-[var(--turquoise)]/10 hover:border-[var(--turquoise)]/30 transition-colors"
+          >
+            <div>
+              <p className="font-medium text-[var(--cream)]">HubSpot Integration</p>
+              <p className="text-sm text-[var(--cream)]/60">Connect and configure</p>
+            </div>
+            <ArrowRight className="w-4 h-4 text-[var(--turquoise)] ml-auto group-hover:translate-x-1 transition-transform" />
+          </Link>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/app/docs/layout.tsx
+++ b/app/docs/layout.tsx
@@ -1,5 +1,7 @@
 import { Navigation } from "@/components/shared/Navigation";
 import { DocsSidebar } from "@/components/docs/DocsSidebar";
+import { Breadcrumbs } from "@/components/docs/Breadcrumbs";
+import { PageNavigation } from "@/components/docs/PageNavigation";
 
 export const metadata = {
   title: "Documentation - ABM.dev",
@@ -17,8 +19,10 @@ export default function DocsLayout({
       <div className="container mx-auto px-4 sm:px-6 lg:px-8 py-8">
         <div className="flex gap-8">
           <DocsSidebar />
-          <main className="flex-1 min-w-0 max-w-4xl">
+          <main id="main-content" className="flex-1 min-w-0 max-w-4xl">
+            <Breadcrumbs />
             {children}
+            <PageNavigation />
           </main>
         </div>
       </div>

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { useEffect } from "react";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { AlertTriangle, RefreshCw, Home } from "lucide-react";
+
+interface ErrorProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+export default function Error({ error, reset }: ErrorProps) {
+  useEffect(() => {
+    // Log error to error reporting service (Sentry, etc.)
+    // This is where you'd integrate with your error tracking
+    if (process.env.NODE_ENV === "production") {
+      // Example: Sentry.captureException(error);
+    }
+  }, [error]);
+
+  return (
+    <div className="min-h-screen bg-[var(--dark-blue)] flex items-center justify-center px-4">
+      <div className="max-w-md w-full text-center">
+        {/* Error Icon */}
+        <div className="mb-6 flex justify-center">
+          <div className="w-16 h-16 rounded-full bg-red-500/10 flex items-center justify-center">
+            <AlertTriangle className="w-8 h-8 text-red-500" />
+          </div>
+        </div>
+
+        {/* Message */}
+        <h1 className="text-2xl font-serif text-[var(--cream)] mb-3">
+          Something went wrong
+        </h1>
+        <p className="text-[var(--cream)]/70 mb-6">
+          We encountered an unexpected error. Please try again or contact support if the problem persists.
+        </p>
+
+        {/* Error Details (development only) */}
+        {process.env.NODE_ENV === "development" && (
+          <div className="mb-6 p-4 rounded-lg bg-red-500/10 border border-red-500/20 text-left">
+            <p className="text-xs font-mono text-red-400 break-all">
+              {error.message}
+            </p>
+            {error.digest && (
+              <p className="text-xs font-mono text-red-400/60 mt-2">
+                Error ID: {error.digest}
+              </p>
+            )}
+          </div>
+        )}
+
+        {/* Actions */}
+        <div className="flex flex-col sm:flex-row items-center justify-center gap-3">
+          <Button
+            onClick={reset}
+            className="bg-[var(--turquoise)] text-[var(--dark-blue)] hover:bg-[var(--dark-turquoise)] w-full sm:w-auto"
+          >
+            <RefreshCw className="w-4 h-4 mr-2" />
+            Try Again
+          </Button>
+          <Button
+            asChild
+            variant="outline"
+            className="border-[var(--turquoise)]/30 text-[var(--cream)] hover:bg-[var(--turquoise)]/10 w-full sm:w-auto"
+          >
+            <Link href="/">
+              <Home className="w-4 h-4 mr-2" />
+              Go Home
+            </Link>
+          </Button>
+        </div>
+
+        {/* Support Link */}
+        <p className="mt-8 text-sm text-[var(--cream)]/50">
+          Need help?{" "}
+          <a
+            href="mailto:support@abm.dev"
+            className="text-[var(--turquoise)] hover:underline"
+          >
+            Contact Support
+          </a>
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,12 +1,61 @@
 import type { Metadata } from "next";
 import { ClerkProvider } from "@clerk/nextjs";
 import { dark } from "@clerk/themes";
+import { Toaster } from "sonner";
 import { ThemeProvider } from "@/lib/context/theme-context";
+import { SkipToContent } from "@/components/shared/SkipToContent";
 import "./globals.css";
 
 export const metadata: Metadata = {
-  title: "Kong Portal - ABM.dev Developer Portal",
-  description: "Developer portal for ABM.dev API with Kong Gateway integration",
+  title: {
+    default: "ABM.dev - B2B Data Enrichment API",
+    template: "%s | ABM.dev",
+  },
+  description: "Enrich your B2B contacts with verified data from LinkedIn, company databases, and more. Build better ABM campaigns with accurate, real-time data enrichment.",
+  keywords: ["B2B data enrichment", "ABM", "account-based marketing", "data enrichment API", "LinkedIn enrichment", "contact enrichment", "CRM integration"],
+  authors: [{ name: "ABM.dev" }],
+  creator: "ABM.dev",
+  publisher: "ABM.dev",
+  metadataBase: new URL(process.env.NEXT_PUBLIC_APP_URL || "https://portal.abm.dev"),
+  openGraph: {
+    type: "website",
+    locale: "en_US",
+    url: "/",
+    siteName: "ABM.dev",
+    title: "ABM.dev - B2B Data Enrichment API",
+    description: "Enrich your B2B contacts with verified data from LinkedIn, company databases, and more.",
+    images: [
+      {
+        url: "/og-image.png",
+        width: 1200,
+        height: 630,
+        alt: "ABM.dev - B2B Data Enrichment",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "ABM.dev - B2B Data Enrichment API",
+    description: "Enrich your B2B contacts with verified data from LinkedIn, company databases, and more.",
+    images: ["/og-image.png"],
+  },
+  robots: {
+    index: true,
+    follow: true,
+    googleBot: {
+      index: true,
+      follow: true,
+      "max-video-preview": -1,
+      "max-image-preview": "large",
+      "max-snippet": -1,
+    },
+  },
+  icons: {
+    icon: "/favicon.ico",
+    shortcut: "/favicon-16x16.png",
+    apple: "/apple-touch-icon.png",
+  },
+  manifest: "/site.webmanifest",
 };
 
 // ABM.dev Dark Theme for Clerk
@@ -98,8 +147,25 @@ export default function RootLayout({
           <script dangerouslySetInnerHTML={{ __html: themeScript }} />
         </head>
         <body className="antialiased">
+          <SkipToContent />
           <ThemeProvider>
             {children}
+            <Toaster
+              position="bottom-right"
+              toastOptions={{
+                style: {
+                  background: "var(--dark-blue)",
+                  border: "1px solid rgba(64, 224, 208, 0.2)",
+                  color: "var(--cream)",
+                },
+                classNames: {
+                  success: "!border-emerald-500/30 !bg-emerald-500/10",
+                  error: "!border-red-500/30 !bg-red-500/10",
+                  warning: "!border-amber-500/30 !bg-amber-500/10",
+                  info: "!border-blue-500/30 !bg-blue-500/10",
+                },
+              }}
+            />
           </ThemeProvider>
         </body>
       </html>

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,88 @@
+import Link from "next/link";
+import { Navigation } from "@/components/shared/Navigation";
+import { Button } from "@/components/ui/button";
+import { Home, ArrowLeft, Search } from "lucide-react";
+
+export default function NotFound() {
+  return (
+    <div className="min-h-screen bg-[var(--dark-blue)]">
+      <Navigation />
+      <main className="container mx-auto px-4 sm:px-6 lg:px-8 py-16">
+        <div className="max-w-2xl mx-auto text-center">
+          {/* 404 Graphic */}
+          <div className="mb-8">
+            <span className="text-8xl font-serif text-[var(--turquoise)]">404</span>
+          </div>
+
+          {/* Message */}
+          <h1 className="text-3xl font-serif text-[var(--cream)] mb-4">
+            Page Not Found
+          </h1>
+          <p className="text-lg text-[var(--cream)]/70 mb-8">
+            The page you&apos;re looking for doesn&apos;t exist or has been moved.
+          </p>
+
+          {/* Actions */}
+          <div className="flex flex-col sm:flex-row items-center justify-center gap-4">
+            <Button
+              asChild
+              className="bg-[var(--turquoise)] text-[var(--dark-blue)] hover:bg-[var(--dark-turquoise)]"
+            >
+              <Link href="/">
+                <Home className="w-4 h-4 mr-2" />
+                Go Home
+              </Link>
+            </Button>
+            <Button
+              asChild
+              variant="outline"
+              className="border-[var(--turquoise)]/30 text-[var(--cream)] hover:bg-[var(--turquoise)]/10"
+            >
+              <Link href="/docs">
+                <Search className="w-4 h-4 mr-2" />
+                Browse Docs
+              </Link>
+            </Button>
+          </div>
+
+          {/* Helpful Links */}
+          <div className="mt-12 p-6 rounded-lg bg-[var(--navy)] border border-[var(--turquoise)]/20">
+            <h2 className="text-lg font-medium text-[var(--cream)] mb-4">
+              Popular Pages
+            </h2>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 text-left">
+              <Link
+                href="/docs/getting-started"
+                className="flex items-center gap-2 p-3 rounded-md text-[var(--cream)]/70 hover:text-[var(--turquoise)] hover:bg-[var(--turquoise)]/5 transition-colors"
+              >
+                <ArrowLeft className="w-4 h-4 rotate-180" />
+                Getting Started
+              </Link>
+              <Link
+                href="/api-reference"
+                className="flex items-center gap-2 p-3 rounded-md text-[var(--cream)]/70 hover:text-[var(--turquoise)] hover:bg-[var(--turquoise)]/5 transition-colors"
+              >
+                <ArrowLeft className="w-4 h-4 rotate-180" />
+                API Reference
+              </Link>
+              <Link
+                href="/dashboard"
+                className="flex items-center gap-2 p-3 rounded-md text-[var(--cream)]/70 hover:text-[var(--turquoise)] hover:bg-[var(--turquoise)]/5 transition-colors"
+              >
+                <ArrowLeft className="w-4 h-4 rotate-180" />
+                Dashboard
+              </Link>
+              <Link
+                href="/settings"
+                className="flex items-center gap-2 p-3 rounded-md text-[var(--cream)]/70 hover:text-[var(--turquoise)] hover:bg-[var(--turquoise)]/5 transition-colors"
+              >
+                <ArrowLeft className="w-4 h-4 rotate-180" />
+                Settings
+              </Link>
+            </div>
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -10,15 +10,6 @@ import { Footer } from "@/components/landing/Footer";
 export default function HomePage() {
   return (
     <div className="min-h-screen bg-[var(--navy)]">
-      {/* Skip to main content link for accessibility */}
-      <a
-        href="#main-content"
-        className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-50 focus:px-4 focus:py-2 focus:bg-[var(--turquoise)] focus:text-[var(--dark-blue)] focus:rounded focus:font-semibold focus:shadow-lg"
-      >
-        Skip to main content
-      </a>
-
-      {/* Custom Navigation - dark theme with auth awareness */}
       <Navigation />
 
       {/* Main Content */}

--- a/components/api-reference/ApiSidebar.tsx
+++ b/components/api-reference/ApiSidebar.tsx
@@ -7,73 +7,84 @@ import { cn } from "@/lib/utils";
 import {
   ChevronDown,
   ChevronRight,
-  Rocket,
-  BookOpen,
-  Key,
-  Puzzle,
+  FileCode,
   Zap,
+  Briefcase,
   Building2,
   Linkedin,
-  FileCode,
-  Settings2,
-  Database,
-  TrendingUp,
-  Layers,
-  ArrowLeftRight
+  Settings,
+  Key,
 } from "lucide-react";
 
 interface NavItem {
   title: string;
   href?: string;
   icon?: React.ReactNode;
+  method?: "GET" | "POST" | "PUT" | "DELETE" | "PATCH";
   items?: NavItem[];
 }
 
-const docsNavigation: NavItem[] = [
+const methodColors = {
+  GET: "text-emerald-400",
+  POST: "text-blue-400",
+  PUT: "text-amber-400",
+  DELETE: "text-red-400",
+  PATCH: "text-purple-400",
+};
+
+const apiNavigation: NavItem[] = [
   {
-    title: "Getting Started",
-    href: "/docs/getting-started",
-    icon: <Rocket className="w-4 h-4" />,
-  },
-  {
-    title: "Concepts",
-    icon: <BookOpen className="w-4 h-4" />,
-    items: [
-      { title: "Authentication", href: "/docs/concepts/authentication" },
-      { title: "Canonical Fields", href: "/docs/concepts/canonical-fields", icon: <Layers className="w-4 h-4" /> },
-      { title: "Confidence Scores", href: "/docs/concepts/confidence-scores", icon: <TrendingUp className="w-4 h-4" /> },
-      { title: "Data Sources", href: "/docs/concepts/data-sources", icon: <Database className="w-4 h-4" /> },
-      { title: "Enrichment", href: "/docs/concepts/enrichment" },
-      { title: "Field Mapping", href: "/docs/concepts/field-mapping", icon: <ArrowLeftRight className="w-4 h-4" /> },
-    ],
-  },
-  {
-    title: "Integration Guides",
-    icon: <Puzzle className="w-4 h-4" />,
-    items: [
-      {
-        title: "HubSpot",
-        href: "/docs/guides/hubspot",
-        icon: <Building2 className="w-4 h-4" />
-      },
-      {
-        title: "LinkedIn",
-        href: "/docs/guides/linkedin",
-        icon: <Linkedin className="w-4 h-4" />
-      },
-    ],
-  },
-  {
-    title: "Advanced",
-    icon: <Settings2 className="w-4 h-4" />,
-    items: [
-      { title: "Enrichment Configuration", href: "/docs/advanced/enrichment-config" },
-    ],
-  },
-  {
-    title: "API Reference",
+    title: "Overview",
     href: "/api-reference",
     icon: <FileCode className="w-4 h-4" />,
+  },
+  {
+    title: "Enrichment",
+    icon: <Zap className="w-4 h-4" />,
+    items: [
+      { title: "Enrich Contact", href: "/api-reference/enrichment#enrich", method: "POST" },
+      { title: "Batch Enrich", href: "/api-reference/enrichment#batch", method: "POST" },
+    ],
+  },
+  {
+    title: "Jobs",
+    icon: <Briefcase className="w-4 h-4" />,
+    items: [
+      { title: "List Jobs", href: "/api-reference/jobs#list", method: "GET" },
+      { title: "Get Job", href: "/api-reference/jobs#get", method: "GET" },
+      { title: "Get Results", href: "/api-reference/jobs#results", method: "GET" },
+    ],
+  },
+  {
+    title: "CRM Integrations",
+    icon: <Building2 className="w-4 h-4" />,
+    items: [
+      { title: "List Integrations", href: "/api-reference/integrations#list", method: "GET" },
+      { title: "Configure", href: "/api-reference/integrations#configure", method: "POST" },
+      { title: "Test Connection", href: "/api-reference/integrations#test", method: "POST" },
+      { title: "Delete Integration", href: "/api-reference/integrations#delete", method: "DELETE" },
+    ],
+  },
+  {
+    title: "LinkedIn",
+    icon: <Linkedin className="w-4 h-4" />,
+    items: [
+      { title: "Initialize", href: "/api-reference/linkedin#initialize", method: "POST" },
+      { title: "Verify", href: "/api-reference/linkedin#verify", method: "POST" },
+      { title: "Get Status", href: "/api-reference/linkedin#status", method: "GET" },
+      { title: "Availability", href: "/api-reference/linkedin#availability", method: "GET" },
+      { title: "Disconnect", href: "/api-reference/linkedin#disconnect", method: "DELETE" },
+      { title: "Cleanup Sessions", href: "/api-reference/linkedin#cleanup", method: "POST" },
+    ],
+  },
+  {
+    title: "Configuration",
+    icon: <Settings className="w-4 h-4" />,
+    items: [
+      { title: "Organization", href: "/api-reference/configuration#organization", method: "GET" },
+      { title: "Update Settings", href: "/api-reference/configuration#update-settings", method: "PATCH" },
+      { title: "Health Check", href: "/api-reference/configuration#status", method: "GET" },
+    ],
   },
 ];
 
@@ -82,11 +93,19 @@ interface NavSectionProps {
   pathname: string;
 }
 
+function MethodBadge({ method }: { method: string }) {
+  return (
+    <span className={cn("font-mono text-xs font-medium", methodColors[method as keyof typeof methodColors])}>
+      {method}
+    </span>
+  );
+}
+
 function NavSection({ item, pathname }: NavSectionProps) {
   const hasChildren = item.items && item.items.length > 0;
-  const isActive = item.href === pathname;
+  const isActive = item.href === pathname || pathname.startsWith(item.href + "#");
   const isChildActive = hasChildren && item.items?.some(
-    child => child.href === pathname
+    child => pathname === child.href || pathname.startsWith((child.href || "").split("#")[0])
   );
   const [isOpen, setIsOpen] = useState(isChildActive || false);
 
@@ -118,14 +137,14 @@ function NavSection({ item, pathname }: NavSectionProps) {
                 key={child.href}
                 href={child.href!}
                 className={cn(
-                  "flex items-center gap-2 px-3 py-2 text-sm rounded-md transition-colors",
+                  "flex items-center justify-between px-3 py-2 text-sm rounded-md transition-colors",
                   pathname === child.href
                     ? "text-[var(--turquoise)] bg-[var(--turquoise)]/10 font-medium"
                     : "text-[var(--cream)]/60 hover:text-[var(--cream)] hover:bg-[var(--turquoise)]/5"
                 )}
               >
-                {child.icon}
-                {child.title}
+                <span>{child.title}</span>
+                {child.method && <MethodBadge method={child.method} />}
               </Link>
             ))}
           </div>
@@ -150,7 +169,7 @@ function NavSection({ item, pathname }: NavSectionProps) {
   );
 }
 
-export function DocsSidebar() {
+export function ApiSidebar() {
   const pathname = usePathname();
 
   return (
@@ -159,20 +178,20 @@ export function DocsSidebar() {
         {/* Logo/Title */}
         <div className="px-3">
           <Link
-            href="/docs"
+            href="/api-reference"
             className="flex items-center gap-2 text-lg font-semibold text-[var(--cream)]"
           >
-            <Zap className="w-5 h-5 text-[var(--turquoise)]" />
-            Documentation
+            <FileCode className="w-5 h-5 text-[var(--turquoise)]" />
+            API Reference
           </Link>
           <p className="mt-1 text-sm text-[var(--cream)]/50">
-            Learn how to use ABM.dev
+            v1.0 &middot; REST API
           </p>
         </div>
 
         {/* Navigation */}
-        <nav className="space-y-1" aria-label="Documentation navigation">
-          {docsNavigation.map((item) => (
+        <nav className="space-y-1" aria-label="API reference navigation">
+          {apiNavigation.map((item) => (
             <NavSection key={item.title} item={item} pathname={pathname} />
           ))}
         </nav>
@@ -189,6 +208,13 @@ export function DocsSidebar() {
             >
               <Key className="w-4 h-4" />
               Get API Key
+            </Link>
+            <Link
+              href="/docs"
+              className="flex items-center gap-2 px-3 py-2 text-sm text-[var(--cream)]/60 hover:text-[var(--cream)] rounded-md transition-colors"
+            >
+              <FileCode className="w-4 h-4" />
+              Documentation
             </Link>
           </div>
         </div>

--- a/components/api-reference/EndpointCard.tsx
+++ b/components/api-reference/EndpointCard.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import { useState } from "react";
+import { cn } from "@/lib/utils";
+import { MethodBadge } from "./MethodBadge";
+import { ParameterTable, Parameter } from "./ParameterTable";
+import { ResponseExample } from "./ResponseExample";
+import { ChevronDown, ChevronRight, Copy, Check } from "lucide-react";
+
+interface EndpointCardProps {
+  id?: string;
+  method: "GET" | "POST" | "PUT" | "DELETE" | "PATCH";
+  path: string;
+  title: string;
+  description?: string;
+  parameters?: Parameter[];
+  requestBody?: {
+    description?: string;
+    example: Record<string, unknown>;
+  };
+  response?: {
+    description?: string;
+    example: Record<string, unknown>;
+  };
+  authenticated?: boolean;
+}
+
+export function EndpointCard({
+  id,
+  method,
+  path,
+  title,
+  description,
+  parameters,
+  requestBody,
+  response,
+  authenticated = true,
+}: EndpointCardProps) {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  const copyPath = () => {
+    navigator.clipboard.writeText(path);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <div
+      id={id}
+      className="border border-[var(--turquoise)]/20 rounded-lg overflow-hidden bg-[var(--dark-blue)]/50"
+    >
+      {/* Header */}
+      <button
+        onClick={() => setIsExpanded(!isExpanded)}
+        className="w-full flex items-center justify-between p-4 hover:bg-[var(--turquoise)]/5 transition-colors"
+      >
+        <div className="flex items-center gap-3">
+          <MethodBadge method={method} />
+          <code className="text-sm text-[var(--cream)]/80 font-mono">{path}</code>
+          {authenticated && (
+            <span className="text-xs text-[var(--cream)]/40 px-2 py-0.5 rounded bg-[var(--cream)]/10">
+              Auth Required
+            </span>
+          )}
+        </div>
+        <div className="flex items-center gap-2">
+          <span className="text-sm text-[var(--cream)]/60 hidden sm:block">{title}</span>
+          {isExpanded ? (
+            <ChevronDown className="w-4 h-4 text-[var(--cream)]/60" />
+          ) : (
+            <ChevronRight className="w-4 h-4 text-[var(--cream)]/60" />
+          )}
+        </div>
+      </button>
+
+      {/* Expanded Content */}
+      {isExpanded && (
+        <div className="border-t border-[var(--turquoise)]/20 p-4 space-y-6">
+          {/* Description */}
+          {description && (
+            <p className="text-[var(--cream)]/70">{description}</p>
+          )}
+
+          {/* Endpoint Path */}
+          <div>
+            <h4 className="text-sm font-medium text-[var(--cream)] mb-2">Endpoint</h4>
+            <div className="flex items-center gap-2 p-3 rounded-lg bg-[var(--navy)] border border-[var(--turquoise)]/10">
+              <code className="flex-1 text-sm font-mono text-[var(--turquoise)]">
+                {method} https://api.abm.dev{path}
+              </code>
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  copyPath();
+                }}
+                className="p-1.5 rounded hover:bg-[var(--turquoise)]/10 transition-colors"
+              >
+                {copied ? (
+                  <Check className="w-4 h-4 text-emerald-400" />
+                ) : (
+                  <Copy className="w-4 h-4 text-[var(--cream)]/60" />
+                )}
+              </button>
+            </div>
+          </div>
+
+          {/* Parameters */}
+          {parameters && parameters.length > 0 && (
+            <div>
+              <h4 className="text-sm font-medium text-[var(--cream)] mb-2">Parameters</h4>
+              <ParameterTable parameters={parameters} />
+            </div>
+          )}
+
+          {/* Request Body */}
+          {requestBody && (
+            <div>
+              <h4 className="text-sm font-medium text-[var(--cream)] mb-2">Request Body</h4>
+              {requestBody.description && (
+                <p className="text-sm text-[var(--cream)]/60 mb-2">{requestBody.description}</p>
+              )}
+              <ResponseExample json={requestBody.example} title="Example Request" />
+            </div>
+          )}
+
+          {/* Response */}
+          {response && (
+            <div>
+              <h4 className="text-sm font-medium text-[var(--cream)] mb-2">Response</h4>
+              {response.description && (
+                <p className="text-sm text-[var(--cream)]/60 mb-2">{response.description}</p>
+              )}
+              <ResponseExample json={response.example} title="Example Response" />
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/api-reference/MethodBadge.tsx
+++ b/components/api-reference/MethodBadge.tsx
@@ -1,0 +1,28 @@
+import { cn } from "@/lib/utils";
+
+const methodStyles = {
+  GET: "bg-emerald-500/20 text-emerald-400 border-emerald-500/30",
+  POST: "bg-blue-500/20 text-blue-400 border-blue-500/30",
+  PUT: "bg-amber-500/20 text-amber-400 border-amber-500/30",
+  DELETE: "bg-red-500/20 text-red-400 border-red-500/30",
+  PATCH: "bg-purple-500/20 text-purple-400 border-purple-500/30",
+};
+
+interface MethodBadgeProps {
+  method: keyof typeof methodStyles;
+  className?: string;
+}
+
+export function MethodBadge({ method, className }: MethodBadgeProps) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center px-2 py-0.5 rounded text-xs font-mono font-semibold border",
+        methodStyles[method],
+        className
+      )}
+    >
+      {method}
+    </span>
+  );
+}

--- a/components/api-reference/ParameterTable.tsx
+++ b/components/api-reference/ParameterTable.tsx
@@ -1,0 +1,61 @@
+import { cn } from "@/lib/utils";
+
+export interface Parameter {
+  name: string;
+  type: string;
+  required?: boolean;
+  description: string;
+  location?: "path" | "query" | "header" | "body";
+}
+
+interface ParameterTableProps {
+  parameters: Parameter[];
+}
+
+export function ParameterTable({ parameters }: ParameterTableProps) {
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b border-[var(--turquoise)]/20">
+            <th className="text-left py-2 pr-4 text-[var(--cream)]/60 font-medium">Name</th>
+            <th className="text-left py-2 pr-4 text-[var(--cream)]/60 font-medium">Type</th>
+            <th className="text-left py-2 pr-4 text-[var(--cream)]/60 font-medium hidden sm:table-cell">Location</th>
+            <th className="text-left py-2 text-[var(--cream)]/60 font-medium">Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          {parameters.map((param) => (
+            <tr key={param.name} className="border-b border-[var(--turquoise)]/10">
+              <td className="py-3 pr-4">
+                <div className="flex items-center gap-2">
+                  <code className="text-[var(--turquoise)] font-mono">{param.name}</code>
+                  {param.required && (
+                    <span className="text-xs text-red-400">*</span>
+                  )}
+                </div>
+              </td>
+              <td className="py-3 pr-4">
+                <code className="text-[var(--cream)]/70 font-mono text-xs bg-[var(--navy)] px-1.5 py-0.5 rounded">
+                  {param.type}
+                </code>
+              </td>
+              <td className="py-3 pr-4 hidden sm:table-cell">
+                <span className={cn(
+                  "text-xs px-2 py-0.5 rounded",
+                  param.location === "path" && "bg-amber-500/20 text-amber-400",
+                  param.location === "query" && "bg-blue-500/20 text-blue-400",
+                  param.location === "header" && "bg-purple-500/20 text-purple-400",
+                  param.location === "body" && "bg-emerald-500/20 text-emerald-400",
+                )}>
+                  {param.location || "body"}
+                </span>
+              </td>
+              <td className="py-3 text-[var(--cream)]/60">{param.description}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/components/api-reference/ResponseExample.tsx
+++ b/components/api-reference/ResponseExample.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { useState } from "react";
+import { Copy, Check } from "lucide-react";
+
+interface ResponseExampleProps {
+  json: Record<string, unknown>;
+  title?: string;
+}
+
+export function ResponseExample({ json, title }: ResponseExampleProps) {
+  const [copied, setCopied] = useState(false);
+  const formatted = JSON.stringify(json, null, 2);
+
+  const copyCode = () => {
+    navigator.clipboard.writeText(formatted);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <div className="rounded-lg overflow-hidden border border-[var(--turquoise)]/20 bg-[var(--navy)]">
+      {/* Header */}
+      <div className="flex items-center justify-between px-4 py-2 border-b border-[var(--turquoise)]/10 bg-[var(--dark-blue)]/50">
+        <span className="text-xs font-medium text-[var(--cream)]/60">
+          {title || "JSON"}
+        </span>
+        <button
+          onClick={copyCode}
+          className="flex items-center gap-1.5 px-2 py-1 text-xs text-[var(--cream)]/60 hover:text-[var(--cream)] rounded transition-colors"
+        >
+          {copied ? (
+            <>
+              <Check className="w-3.5 h-3.5 text-emerald-400" />
+              Copied
+            </>
+          ) : (
+            <>
+              <Copy className="w-3.5 h-3.5" />
+              Copy
+            </>
+          )}
+        </button>
+      </div>
+
+      {/* Code */}
+      <pre className="p-4 overflow-x-auto text-sm">
+        <code className="text-[var(--cream)]/80 font-mono">
+          {formatJsonWithHighlighting(json)}
+        </code>
+      </pre>
+    </div>
+  );
+}
+
+function formatJsonWithHighlighting(obj: Record<string, unknown>, indent = 0): React.ReactNode {
+  const spaces = "  ".repeat(indent);
+  const entries = Object.entries(obj);
+
+  if (entries.length === 0) {
+    return "{}";
+  }
+
+  return (
+    <>
+      {"{\n"}
+      {entries.map(([key, value], index) => (
+        <span key={key}>
+          {spaces}{"  "}
+          <span className="text-[var(--turquoise)]">"{key}"</span>
+          {": "}
+          {formatValue(value, indent + 1)}
+          {index < entries.length - 1 ? ",\n" : "\n"}
+        </span>
+      ))}
+      {spaces}{"}"}
+    </>
+  );
+}
+
+function formatValue(value: unknown, indent: number): React.ReactNode {
+  if (value === null) {
+    return <span className="text-[var(--cream)]/50">null</span>;
+  }
+
+  if (typeof value === "boolean") {
+    return <span className="text-amber-400">{value.toString()}</span>;
+  }
+
+  if (typeof value === "number") {
+    return <span className="text-emerald-400">{value}</span>;
+  }
+
+  if (typeof value === "string") {
+    return <span className="text-amber-300">"{value}"</span>;
+  }
+
+  if (Array.isArray(value)) {
+    if (value.length === 0) {
+      return "[]";
+    }
+    const spaces = "  ".repeat(indent);
+    return (
+      <>
+        {"[\n"}
+        {value.map((item, index) => (
+          <span key={index}>
+            {spaces}{"  "}
+            {formatValue(item, indent + 1)}
+            {index < value.length - 1 ? ",\n" : "\n"}
+          </span>
+        ))}
+        {spaces}{"]"}
+      </>
+    );
+  }
+
+  if (typeof value === "object") {
+    return formatJsonWithHighlighting(value as Record<string, unknown>, indent);
+  }
+
+  return String(value);
+}

--- a/components/api-reference/index.ts
+++ b/components/api-reference/index.ts
@@ -1,1 +1,7 @@
 export { ApiReference } from './ApiReference';
+export { ApiSidebar } from './ApiSidebar';
+export { MethodBadge } from './MethodBadge';
+export { EndpointCard } from './EndpointCard';
+export { ParameterTable } from './ParameterTable';
+export type { Parameter } from './ParameterTable';
+export { ResponseExample } from './ResponseExample';

--- a/components/dashboard/ActivityFeed.tsx
+++ b/components/dashboard/ActivityFeed.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import { Zap, Key, Link as LinkIcon, Settings, CheckCircle2, AlertCircle } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface Activity {
+  id: string;
+  type: 'enrichment' | 'api_key' | 'integration' | 'settings';
+  title: string;
+  description: string;
+  timestamp: string;
+  status?: 'success' | 'error' | 'pending';
+}
+
+const activityIcons = {
+  enrichment: Zap,
+  api_key: Key,
+  integration: LinkIcon,
+  settings: Settings,
+};
+
+const statusIcons = {
+  success: CheckCircle2,
+  error: AlertCircle,
+  pending: null,
+};
+
+interface ActivityFeedProps {
+  activities: Activity[];
+  className?: string;
+}
+
+export function ActivityFeed({ activities, className }: ActivityFeedProps) {
+  if (activities.length === 0) {
+    return (
+      <div className={cn("p-6 rounded-lg bg-[var(--navy)] border border-[var(--turquoise)]/20", className)}>
+        <p className="text-center text-[var(--cream)]/50 py-8">
+          No recent activity to display
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className={cn("p-6 rounded-lg bg-[var(--navy)] border border-[var(--turquoise)]/20", className)}>
+      <h3 className="text-lg font-medium text-[var(--cream)] mb-4">Recent Activity</h3>
+      <div className="space-y-4">
+        {activities.map((activity) => {
+          const Icon = activityIcons[activity.type];
+          const StatusIcon = activity.status ? statusIcons[activity.status] : null;
+
+          return (
+            <div
+              key={activity.id}
+              className="flex items-start gap-3 p-3 rounded-lg bg-[var(--turquoise)]/5 border border-[var(--turquoise)]/10"
+            >
+              <div className="p-2 rounded-lg bg-[var(--dark-blue)]">
+                <Icon className="w-4 h-4 text-[var(--turquoise)]" />
+              </div>
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-2">
+                  <p className="text-sm font-medium text-[var(--cream)]">{activity.title}</p>
+                  {StatusIcon && (
+                    <StatusIcon className={cn(
+                      "w-4 h-4",
+                      activity.status === 'success' && "text-emerald-400",
+                      activity.status === 'error' && "text-red-400"
+                    )} />
+                  )}
+                </div>
+                <p className="text-xs text-[var(--cream)]/60">{activity.description}</p>
+              </div>
+              <span className="text-xs text-[var(--cream)]/40 whitespace-nowrap">
+                {activity.timestamp}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/components/dashboard/IntegrationStatus.tsx
+++ b/components/dashboard/IntegrationStatus.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import Link from 'next/link';
+import { Linkedin, ChevronRight, CheckCircle2, XCircle } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+// Icon components
+function HubSpotIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="currentColor">
+      <path d="M18.164 7.93V5.084a2.198 2.198 0 001.267-1.984v-.066a2.198 2.198 0 00-4.396 0V3.1c0 .9.54 1.67 1.313 2.012v2.789a5.42 5.42 0 00-2.477 1.277l-6.44-5.019a2.385 2.385 0 00.092-.642v-.065a2.385 2.385 0 10-2.556 2.376 2.375 2.375 0 001.045-.239l6.317 4.923a5.454 5.454 0 00-.77 2.796 5.464 5.464 0 00.787 2.843l-1.907 1.907a1.81 1.81 0 00-.527-.082 1.834 1.834 0 101.833 1.833c0-.184-.029-.36-.08-.527l1.89-1.89a5.456 5.456 0 108.009-8.463 5.426 5.426 0 00-3.4-1.092zm-.117 8.442a2.85 2.85 0 110-5.702 2.85 2.85 0 010 5.702z" />
+    </svg>
+  );
+}
+
+function SalesforceIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="currentColor">
+      <path d="M9.98 6.182a4.27 4.27 0 013.38-1.655 4.277 4.277 0 013.967 2.674 3.643 3.643 0 011.404-.28 3.675 3.675 0 013.678 3.678 3.643 3.643 0 01-.285 1.416 3.196 3.196 0 011.877 2.914 3.203 3.203 0 01-3.203 3.203 3.203 3.203 0 01-.54-.046 3.95 3.95 0 01-3.487 2.089 3.947 3.947 0 01-1.772-.418 4.494 4.494 0 01-7.83-1.573 3.315 3.315 0 01-.616.058 3.34 3.34 0 01-3.34-3.34 3.34 3.34 0 012.035-3.074 4.072 4.072 0 01-.19-1.234 4.094 4.094 0 014.094-4.094 4.072 4.072 0 01.828.085z" />
+    </svg>
+  );
+}
+
+interface Integration {
+  id: string;
+  name: string;
+  icon: React.ComponentType<{ className?: string }>;
+  iconColor: string;
+  connected: boolean;
+  href: string;
+}
+
+const integrations: Integration[] = [
+  {
+    id: 'linkedin',
+    name: 'LinkedIn',
+    icon: Linkedin,
+    iconColor: 'text-[#0A66C2]',
+    connected: false,
+    href: '/settings/linkedin',
+  },
+  {
+    id: 'hubspot',
+    name: 'HubSpot',
+    icon: HubSpotIcon,
+    iconColor: 'text-[#ff7a59]',
+    connected: false,
+    href: '/settings/hubspot',
+  },
+  {
+    id: 'salesforce',
+    name: 'Salesforce',
+    icon: SalesforceIcon,
+    iconColor: 'text-[#00a1e0]',
+    connected: false,
+    href: '/settings/salesforce',
+  },
+];
+
+interface IntegrationStatusProps {
+  className?: string;
+}
+
+export function IntegrationStatus({ className }: IntegrationStatusProps) {
+  const connectedCount = integrations.filter((i) => i.connected).length;
+
+  return (
+    <div className={cn("p-6 rounded-lg bg-[var(--navy)] border border-[var(--turquoise)]/20", className)}>
+      <div className="flex items-center justify-between mb-4">
+        <h3 className="text-lg font-medium text-[var(--cream)]">Integrations</h3>
+        <span className="text-sm text-[var(--cream)]/60">
+          {connectedCount}/{integrations.length} connected
+        </span>
+      </div>
+      <div className="space-y-3">
+        {integrations.map((integration) => {
+          const Icon = integration.icon;
+          return (
+            <Link
+              key={integration.id}
+              href={integration.href}
+              className="flex items-center justify-between p-3 rounded-lg bg-[var(--turquoise)]/5 border border-[var(--turquoise)]/10 hover:border-[var(--turquoise)]/30 transition-colors group"
+            >
+              <div className="flex items-center gap-3">
+                <div className="p-2 rounded-lg bg-[var(--dark-blue)]">
+                  <Icon className={cn("w-4 h-4", integration.iconColor)} />
+                </div>
+                <span className="text-sm text-[var(--cream)]">{integration.name}</span>
+              </div>
+              <div className="flex items-center gap-2">
+                {integration.connected ? (
+                  <CheckCircle2 className="w-4 h-4 text-emerald-400" />
+                ) : (
+                  <XCircle className="w-4 h-4 text-[var(--cream)]/30" />
+                )}
+                <ChevronRight className="w-4 h-4 text-[var(--cream)]/30 group-hover:text-[var(--turquoise)] transition-colors" />
+              </div>
+            </Link>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/components/dashboard/StatsCard.tsx
+++ b/components/dashboard/StatsCard.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import { LucideIcon, TrendingUp, TrendingDown, Minus } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface StatsCardProps {
+  title: string;
+  value: string | number;
+  icon: LucideIcon;
+  change?: {
+    value: number;
+    period: string;
+  };
+  subtitle?: string;
+  className?: string;
+}
+
+export function StatsCard({ title, value, icon: Icon, change, subtitle, className }: StatsCardProps) {
+  const isPositive = change && change.value > 0;
+  const isNegative = change && change.value < 0;
+  const isNeutral = change && change.value === 0;
+
+  return (
+    <div className={cn(
+      "p-6 rounded-lg bg-[var(--navy)] border border-[var(--turquoise)]/20",
+      className
+    )}>
+      <div className="flex items-start justify-between">
+        <div className="space-y-1">
+          <p className="text-sm text-[var(--cream)]/60">{title}</p>
+          <p className="text-2xl font-semibold text-[var(--cream)]">{value}</p>
+          {change && (
+            <div className="flex items-center gap-1 mt-2">
+              {isPositive && <TrendingUp className="w-4 h-4 text-emerald-400" />}
+              {isNegative && <TrendingDown className="w-4 h-4 text-red-400" />}
+              {isNeutral && <Minus className="w-4 h-4 text-[var(--cream)]/40" />}
+              <span className={cn(
+                "text-sm",
+                isPositive && "text-emerald-400",
+                isNegative && "text-red-400",
+                isNeutral && "text-[var(--cream)]/40"
+              )}>
+                {isPositive && '+'}{change.value}%
+              </span>
+              <span className="text-sm text-[var(--cream)]/40">{change.period}</span>
+            </div>
+          )}
+          {subtitle && (
+            <p className="text-xs text-[var(--cream)]/40 mt-1">{subtitle}</p>
+          )}
+        </div>
+        <div className="p-3 rounded-lg bg-[var(--turquoise)]/10">
+          <Icon className="w-6 h-6 text-[var(--turquoise)]" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/dashboard/UsageBar.tsx
+++ b/components/dashboard/UsageBar.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { cn } from '@/lib/utils';
+
+interface UsageBarProps {
+  label: string;
+  used: number;
+  limit: number;
+  unit?: string;
+  className?: string;
+}
+
+export function UsageBar({ label, used, limit, unit = '', className }: UsageBarProps) {
+  const percentage = Math.min((used / limit) * 100, 100);
+  const isWarning = percentage > 70;
+  const isCritical = percentage > 90;
+
+  return (
+    <div className={cn("space-y-2", className)}>
+      <div className="flex items-center justify-between">
+        <span className="text-sm text-[var(--cream)]/70">{label}</span>
+        <span className="text-sm text-[var(--cream)]">
+          {used.toLocaleString()}{unit} / {limit.toLocaleString()}{unit}
+        </span>
+      </div>
+      <div className="h-2 rounded-full bg-[var(--turquoise)]/10 overflow-hidden">
+        <div
+          className={cn(
+            "h-full rounded-full transition-all duration-500",
+            isCritical ? "bg-red-500" : isWarning ? "bg-amber-500" : "bg-[var(--turquoise)]"
+          )}
+          style={{ width: `${percentage}%` }}
+        />
+      </div>
+      <p className="text-xs text-[var(--cream)]/40">
+        {(limit - used).toLocaleString()}{unit} remaining
+      </p>
+    </div>
+  );
+}

--- a/components/dashboard/index.ts
+++ b/components/dashboard/index.ts
@@ -1,0 +1,4 @@
+export { StatsCard } from './StatsCard';
+export { UsageBar } from './UsageBar';
+export { ActivityFeed } from './ActivityFeed';
+export { IntegrationStatus } from './IntegrationStatus';

--- a/components/docs/Breadcrumbs.tsx
+++ b/components/docs/Breadcrumbs.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { ChevronRight, Home } from "lucide-react";
+import { getBreadcrumbs } from "@/lib/docs-navigation";
+
+export function Breadcrumbs() {
+  const pathname = usePathname();
+  const breadcrumbs = getBreadcrumbs(pathname);
+
+  if (breadcrumbs.length <= 1) {
+    return null;
+  }
+
+  return (
+    <nav aria-label="Breadcrumb" className="mb-6">
+      <ol className="flex items-center gap-1 text-sm text-[var(--cream)]/60">
+        <li>
+          <Link
+            href="/"
+            className="flex items-center gap-1 hover:text-[var(--turquoise)] transition-colors"
+          >
+            <Home className="w-3.5 h-3.5" />
+            <span className="sr-only">Home</span>
+          </Link>
+        </li>
+        {breadcrumbs.map((crumb, index) => (
+          <li key={index} className="flex items-center gap-1">
+            <ChevronRight className="w-3.5 h-3.5 text-[var(--cream)]/40" />
+            {crumb.href && index < breadcrumbs.length - 1 ? (
+              <Link
+                href={crumb.href}
+                className="hover:text-[var(--turquoise)] transition-colors"
+              >
+                {crumb.title}
+              </Link>
+            ) : (
+              <span className={index === breadcrumbs.length - 1 ? "text-[var(--cream)]" : ""}>
+                {crumb.title}
+              </span>
+            )}
+          </li>
+        ))}
+      </ol>
+    </nav>
+  );
+}

--- a/components/docs/DocsSidebar.tsx
+++ b/components/docs/DocsSidebar.tsx
@@ -14,7 +14,12 @@ import {
   Zap,
   Building2,
   Linkedin,
-  FileCode
+  FileCode,
+  Settings2,
+  Database,
+  TrendingUp,
+  Layers,
+  ArrowLeftRight
 } from "lucide-react";
 
 interface NavItem {
@@ -35,6 +40,10 @@ const docsNavigation: NavItem[] = [
     icon: <BookOpen className="w-4 h-4" />,
     items: [
       { title: "How Enrichment Works", href: "/docs/concepts/enrichment" },
+      { title: "Canonical Fields", href: "/docs/concepts/canonical-fields", icon: <Layers className="w-4 h-4" /> },
+      { title: "Confidence Scores", href: "/docs/concepts/confidence-scores", icon: <TrendingUp className="w-4 h-4" /> },
+      { title: "Field Mapping", href: "/docs/concepts/field-mapping", icon: <ArrowLeftRight className="w-4 h-4" /> },
+      { title: "Data Sources", href: "/docs/concepts/data-sources", icon: <Database className="w-4 h-4" /> },
       { title: "Authentication", href: "/docs/concepts/authentication" },
     ],
   },
@@ -52,6 +61,13 @@ const docsNavigation: NavItem[] = [
         href: "/docs/guides/linkedin",
         icon: <Linkedin className="w-4 h-4" />
       },
+    ],
+  },
+  {
+    title: "Advanced",
+    icon: <Settings2 className="w-4 h-4" />,
+    items: [
+      { title: "Enrichment Configuration", href: "/docs/advanced/enrichment-config" },
     ],
   },
   {

--- a/components/docs/FieldTable.tsx
+++ b/components/docs/FieldTable.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import { useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+import { Search, ChevronDown, ChevronRight } from "lucide-react";
+
+interface Field {
+  name: string;
+  description: string;
+  type: string;
+  example?: string;
+}
+
+interface FieldCategory {
+  name: string;
+  description: string;
+  fields: Field[];
+}
+
+interface FieldTableProps {
+  categories: FieldCategory[];
+  entityType: "person" | "company";
+}
+
+export function FieldTable({ categories, entityType }: FieldTableProps) {
+  const [searchQuery, setSearchQuery] = useState("");
+  const [expandedCategories, setExpandedCategories] = useState<Set<string>>(
+    new Set(categories.map(c => c.name))
+  );
+
+  const toggleCategory = (name: string) => {
+    const newExpanded = new Set(expandedCategories);
+    if (newExpanded.has(name)) {
+      newExpanded.delete(name);
+    } else {
+      newExpanded.add(name);
+    }
+    setExpandedCategories(newExpanded);
+  };
+
+  const filteredCategories = categories.map(category => ({
+    ...category,
+    fields: category.fields.filter(
+      field =>
+        field.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
+        field.description.toLowerCase().includes(searchQuery.toLowerCase())
+    )
+  })).filter(category => category.fields.length > 0);
+
+  const totalFields = categories.reduce((acc, cat) => acc + cat.fields.length, 0);
+
+  return (
+    <div className="space-y-4">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Badge className={cn(
+            "text-xs",
+            entityType === "person"
+              ? "bg-[var(--turquoise)]/20 text-[var(--turquoise)] border-[var(--turquoise)]/30"
+              : "bg-[var(--electric-blue)]/20 text-[var(--electric-blue)] border-[var(--electric-blue)]/30"
+          )}>
+            {totalFields} fields
+          </Badge>
+        </div>
+
+        {/* Search */}
+        <div className="relative">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-[var(--cream)]/40" />
+          <input
+            type="text"
+            placeholder="Search fields..."
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            className="pl-9 pr-4 py-2 text-sm bg-[var(--dark-blue)] border border-[var(--turquoise)]/20 rounded-lg text-[var(--cream)] placeholder:text-[var(--cream)]/40 focus:outline-none focus:border-[var(--turquoise)]/50 w-64"
+          />
+        </div>
+      </div>
+
+      {/* Categories */}
+      <div className="space-y-4">
+        {filteredCategories.map((category) => (
+          <div
+            key={category.name}
+            className="border border-[var(--turquoise)]/20 rounded-lg overflow-hidden"
+          >
+            {/* Category Header */}
+            <button
+              onClick={() => toggleCategory(category.name)}
+              className="w-full flex items-center justify-between px-4 py-3 bg-[var(--dark-blue)]/50 hover:bg-[var(--turquoise)]/5 transition-colors"
+            >
+              <div className="flex items-center gap-3">
+                {expandedCategories.has(category.name) ? (
+                  <ChevronDown className="w-4 h-4 text-[var(--turquoise)]" />
+                ) : (
+                  <ChevronRight className="w-4 h-4 text-[var(--turquoise)]" />
+                )}
+                <span className="font-medium text-[var(--cream)]">
+                  {category.name}
+                </span>
+                <span className="text-sm text-[var(--cream)]/50">
+                  {category.description}
+                </span>
+              </div>
+              <Badge variant="secondary" className="bg-[var(--turquoise)]/10 text-[var(--turquoise)] border-[var(--turquoise)]/20">
+                {category.fields.length}
+              </Badge>
+            </button>
+
+            {/* Fields Table */}
+            {expandedCategories.has(category.name) && (
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b border-[var(--turquoise)]/10 bg-[var(--dark-blue)]/30">
+                      <th className="text-left py-2 px-4 text-[var(--cream)]/70 font-medium">Field</th>
+                      <th className="text-left py-2 px-4 text-[var(--cream)]/70 font-medium">Type</th>
+                      <th className="text-left py-2 px-4 text-[var(--cream)]/70 font-medium">Description</th>
+                      <th className="text-left py-2 px-4 text-[var(--cream)]/70 font-medium">Example</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {category.fields.map((field) => (
+                      <tr
+                        key={field.name}
+                        className="border-b border-[var(--turquoise)]/5 hover:bg-[var(--turquoise)]/5 transition-colors"
+                      >
+                        <td className="py-2 px-4">
+                          <code className="text-xs px-1.5 py-0.5 rounded bg-[var(--turquoise)]/10 text-[var(--turquoise)]">
+                            {field.name}
+                          </code>
+                        </td>
+                        <td className="py-2 px-4 text-[var(--cream)]/60">
+                          {field.type}
+                        </td>
+                        <td className="py-2 px-4 text-[var(--cream)]/70">
+                          {field.description}
+                        </td>
+                        <td className="py-2 px-4 text-[var(--cream)]/50 font-mono text-xs">
+                          {field.example || "—"}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+
+      {filteredCategories.length === 0 && (
+        <div className="text-center py-8 text-[var(--cream)]/50">
+          No fields match your search
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/docs/PageNavigation.tsx
+++ b/components/docs/PageNavigation.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { ArrowLeft, ArrowRight } from "lucide-react";
+import { getPageNavigation } from "@/lib/docs-navigation";
+
+export function PageNavigation() {
+  const pathname = usePathname();
+  const { prev, next } = getPageNavigation(pathname);
+
+  if (!prev && !next) {
+    return null;
+  }
+
+  return (
+    <nav
+      aria-label="Page navigation"
+      className="mt-12 pt-8 border-t border-[var(--turquoise)]/20"
+    >
+      <div className="flex justify-between gap-4">
+        {prev ? (
+          <Link
+            href={prev.href}
+            className="group flex-1 max-w-[50%] p-4 rounded-lg border border-[var(--turquoise)]/20 hover:border-[var(--turquoise)]/40 hover:bg-[var(--turquoise)]/5 transition-all"
+          >
+            <div className="flex items-center gap-2 text-sm text-[var(--cream)]/60 mb-1">
+              <ArrowLeft className="w-4 h-4 group-hover:-translate-x-1 transition-transform" />
+              Previous
+            </div>
+            <div className="font-medium text-[var(--cream)] group-hover:text-[var(--turquoise)] transition-colors">
+              {prev.title}
+            </div>
+            {prev.category && (
+              <div className="text-xs text-[var(--cream)]/50 mt-1">
+                {prev.category}
+              </div>
+            )}
+          </Link>
+        ) : (
+          <div />
+        )}
+
+        {next ? (
+          <Link
+            href={next.href}
+            className="group flex-1 max-w-[50%] p-4 rounded-lg border border-[var(--turquoise)]/20 hover:border-[var(--turquoise)]/40 hover:bg-[var(--turquoise)]/5 transition-all text-right ml-auto"
+          >
+            <div className="flex items-center justify-end gap-2 text-sm text-[var(--cream)]/60 mb-1">
+              Next
+              <ArrowRight className="w-4 h-4 group-hover:translate-x-1 transition-transform" />
+            </div>
+            <div className="font-medium text-[var(--cream)] group-hover:text-[var(--turquoise)] transition-colors">
+              {next.title}
+            </div>
+            {next.category && (
+              <div className="text-xs text-[var(--cream)]/50 mt-1">
+                {next.category}
+              </div>
+            )}
+          </Link>
+        ) : (
+          <div />
+        )}
+      </div>
+    </nav>
+  );
+}

--- a/components/settings/ConnectLinkedInModal.tsx
+++ b/components/settings/ConnectLinkedInModal.tsx
@@ -1,13 +1,13 @@
 'use client';
 
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useEffect, useRef } from 'react';
 import * as Dialog from '@radix-ui/react-dialog';
 import { Button } from '@/components/ui/button';
 import { Linkedin, Loader2, AlertCircle, CheckCircle2, ExternalLink } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { createApiClient } from '@/lib/api-client';
 
-type ConnectionState = 'idle' | 'initializing' | 'waiting' | 'verifying' | 'connected' | 'error';
+type ConnectionState = 'initializing' | 'waiting' | 'verifying' | 'connected' | 'error';
 
 interface InitializeResponse {
   sessionId: string;
@@ -30,6 +30,9 @@ interface ConnectLinkedInModalProps {
   orgId?: string;
 }
 
+// Browserbase Live URL format when API doesn't return it
+const BROWSERBASE_LIVE_URL_BASE = 'https://www.browserbase.com/sessions';
+
 export function ConnectLinkedInModal({
   open,
   onOpenChange,
@@ -37,13 +40,30 @@ export function ConnectLinkedInModal({
   token,
   orgId,
 }: ConnectLinkedInModalProps) {
-  const [state, setState] = useState<ConnectionState>('idle');
+  const [state, setState] = useState<ConnectionState | null>(null);
   const [sessionUrl, setSessionUrl] = useState<string>('');
   const [sessionId, setSessionId] = useState<string>('');
   const [errorMessage, setErrorMessage] = useState<string>('');
+  const hasInitialized = useRef(false);
 
   // Create API client with auth context
   const api = useMemo(() => createApiClient(token, orgId), [token, orgId]);
+
+  // Auto-start initialization when modal opens, reset when it closes
+  useEffect(() => {
+    if (open && !hasInitialized.current) {
+      hasInitialized.current = true;
+      handleInitialize();
+    }
+    // Reset everything when modal closes
+    if (!open && hasInitialized.current) {
+      hasInitialized.current = false;
+      setState(null);
+      setSessionUrl('');
+      setSessionId('');
+      setErrorMessage('');
+    }
+  }, [open]);
 
   const handleInitialize = async () => {
     setState('initializing');
@@ -53,15 +73,28 @@ export function ConnectLinkedInModal({
       const result = await api.post<InitializeResponse>('/v1/linkedin-connection/initialize');
 
       if (!result.success || !result.data) {
+        // Check for session conflict (409)
+        const errorDetails = result.error?.details as { canRetryAfter?: number; sessionAge?: number } | undefined;
+        if (errorDetails?.canRetryAfter !== undefined) {
+          const retryMinutes = errorDetails.canRetryAfter;
+          throw new Error(
+            retryMinutes > 0
+              ? `A session is already in progress. Please wait ${retryMinutes} minute(s) or complete the existing session.`
+              : 'A session is already in progress. It will be automatically cleaned up shortly. Please try again.'
+          );
+        }
         throw new Error(result.error?.message || 'Failed to initialize connection');
       }
 
       setSessionId(result.data.sessionId);
-      setSessionUrl(result.data.sessionUrl);
+
+      // Use API-provided URL or construct Browserbase Live URL from sessionId
+      const liveUrl = result.data.sessionUrl || `${BROWSERBASE_LIVE_URL_BASE}/${result.data.sessionId}/live`;
+      setSessionUrl(liveUrl);
       setState('waiting');
 
       // Open Browserbase Live View in new window
-      window.open(result.data.sessionUrl, '_blank', 'noopener,noreferrer');
+      window.open(liveUrl, '_blank', 'noopener,noreferrer');
     } catch (error) {
       setState('error');
       setErrorMessage(error instanceof Error ? error.message : 'An error occurred');
@@ -92,7 +125,7 @@ export function ConnectLinkedInModal({
   };
 
   const resetModal = () => {
-    setState('idle');
+    setState(null);
     setSessionUrl('');
     setSessionId('');
     setErrorMessage('');
@@ -123,8 +156,7 @@ export function ConnectLinkedInModal({
           </Dialog.Title>
 
           <Dialog.Description className="text-sm text-[var(--cream)]/70 mb-6">
-            {state === 'idle' && 'Connect your LinkedIn account to enable profile data enrichment for your contacts.'}
-            {state === 'initializing' && 'Initializing secure browser session...'}
+            {(state === null || state === 'initializing') && 'Initializing secure browser session...'}
             {state === 'waiting' && 'Please log in to LinkedIn in the new window, then click "I\'m Done" below.'}
             {state === 'verifying' && 'Verifying your LinkedIn connection...'}
             {state === 'connected' && 'Successfully connected your LinkedIn account!'}
@@ -164,19 +196,7 @@ export function ConnectLinkedInModal({
             )}
 
             <div className="flex gap-3">
-              {state === 'idle' && (
-                <>
-                  <Button variant="outline" onClick={handleClose} className="flex-1">
-                    Cancel
-                  </Button>
-                  <Button onClick={handleInitialize} className="flex-1">
-                    <Linkedin className="size-4 mr-2" />
-                    Start Connection
-                  </Button>
-                </>
-              )}
-
-              {state === 'initializing' && (
+              {(state === null || state === 'initializing') && (
                 <Button disabled className="w-full">
                   <Loader2 className="animate-spin size-4 mr-2" />
                   Initializing...

--- a/components/settings/DeleteAccountButton.tsx
+++ b/components/settings/DeleteAccountButton.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { DeleteAccountModal } from './DeleteAccountModal';
+
+export function DeleteAccountButton() {
+  const [modalOpen, setModalOpen] = useState(false);
+
+  return (
+    <>
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={() => setModalOpen(true)}
+        className="border-red-500/50 text-red-400 hover:bg-red-500/10 hover:border-red-500"
+      >
+        Delete Account
+      </Button>
+
+      <DeleteAccountModal open={modalOpen} onOpenChange={setModalOpen} />
+    </>
+  );
+}

--- a/components/settings/DeleteAccountModal.tsx
+++ b/components/settings/DeleteAccountModal.tsx
@@ -1,0 +1,106 @@
+'use client';
+
+import { useState } from 'react';
+import { toast } from 'sonner';
+import { useClerk } from '@clerk/nextjs';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { AlertTriangle, Loader2 } from 'lucide-react';
+
+interface DeleteAccountModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function DeleteAccountModal({ open, onOpenChange }: DeleteAccountModalProps) {
+  const { user } = useClerk();
+  const [confirmText, setConfirmText] = useState('');
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const handleDelete = async () => {
+    if (confirmText !== 'DELETE') {
+      toast.error('Please type DELETE to confirm');
+      return;
+    }
+
+    setIsDeleting(true);
+    try {
+      await user?.delete();
+      toast.success('Account deleted successfully');
+      // User will be redirected by Clerk
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to delete account');
+      setIsDeleting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md bg-[var(--navy)] border-red-500/30">
+        <DialogHeader>
+          <div className="flex items-center gap-3 mb-2">
+            <div className="p-2 rounded-lg bg-red-500/10">
+              <AlertTriangle className="w-6 h-6 text-red-400" />
+            </div>
+            <DialogTitle className="text-red-400">Delete Account</DialogTitle>
+          </div>
+          <DialogDescription className="text-[var(--cream)]/70">
+            This action is permanent and cannot be undone. All your data, API keys, and integrations will be permanently deleted.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 mt-4">
+          <div className="p-4 rounded-lg bg-red-500/10 border border-red-500/20">
+            <p className="text-sm text-red-400">
+              <strong>Warning:</strong> This will immediately:
+            </p>
+            <ul className="mt-2 text-sm text-red-400/80 list-disc list-inside space-y-1">
+              <li>Delete all your API keys</li>
+              <li>Disconnect all integrations</li>
+              <li>Remove all enrichment data</li>
+              <li>Cancel your subscription</li>
+            </ul>
+          </div>
+
+          <div>
+            <label className="block text-sm text-[var(--cream)]/70 mb-2">
+              Type <span className="font-mono text-red-400">DELETE</span> to confirm:
+            </label>
+            <input
+              type="text"
+              value={confirmText}
+              onChange={(e) => setConfirmText(e.target.value)}
+              placeholder="DELETE"
+              className="w-full px-3 py-2 rounded-md bg-[var(--dark-blue)] border border-red-500/30 text-[var(--cream)] placeholder:text-[var(--cream)]/30 focus:outline-none focus:ring-2 focus:ring-red-500/50"
+            />
+          </div>
+
+          <div className="flex gap-3 pt-2">
+            <Button
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              className="flex-1"
+              disabled={isDeleting}
+            >
+              Cancel
+            </Button>
+            <Button
+              onClick={handleDelete}
+              disabled={confirmText !== 'DELETE' || isDeleting}
+              className="flex-1 bg-red-500 hover:bg-red-600 text-white border-0"
+            >
+              {isDeleting ? (
+                <>
+                  <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                  Deleting...
+                </>
+              ) : (
+                'Delete Account'
+              )}
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/settings/HubSpotSettingsCard.tsx
+++ b/components/settings/HubSpotSettingsCard.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState, useMemo } from 'react';
+import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
 import { ConnectHubSpotModal, HubSpotIcon } from './ConnectHubSpotModal';
 import { DisconnectConfirmModal } from './DisconnectConfirmModal';
@@ -92,7 +93,7 @@ export function HubSpotSettingsCard({ token, orgId }: HubSpotSettingsCardProps) 
 
   const handleDisconnect = async () => {
     if (!status?.integrationId) {
-      alert('Cannot disconnect: Integration ID not found');
+      toast.error('Cannot disconnect: Integration ID not found');
       return;
     }
 
@@ -105,9 +106,10 @@ export function HubSpotSettingsCard({ token, orgId }: HubSpotSettingsCardProps) 
       }
 
       setDisconnectModalOpen(false);
+      toast.success('HubSpot account disconnected successfully');
       await refetch();
     } catch (error) {
-      alert(error instanceof Error ? error.message : 'Failed to disconnect HubSpot account');
+      toast.error(error instanceof Error ? error.message : 'Failed to disconnect HubSpot account');
     } finally {
       setIsDisconnecting(false);
     }

--- a/components/shared/SkipToContent.tsx
+++ b/components/shared/SkipToContent.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+export function SkipToContent() {
+  return (
+    <a
+      href="#main-content"
+      className="sr-only focus:not-sr-only focus:fixed focus:top-4 focus:left-4 focus:z-[100] focus:px-4 focus:py-2 focus:rounded-md focus:bg-[var(--turquoise)] focus:text-[var(--dark-blue)] focus:font-semibold focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[var(--turquoise)]"
+    >
+      Skip to main content
+    </a>
+  );
+}

--- a/components/ui/empty-state.tsx
+++ b/components/ui/empty-state.tsx
@@ -188,26 +188,35 @@ EmptyStateNoAPIKeys.displayName = "EmptyStateNoAPIKeys";
 export interface EmptyStateLinkedInNotConnectedProps {
   onConnect?: () => void;
   className?: string;
+  disabled?: boolean;
 }
 
 const EmptyStateLinkedInNotConnected = React.forwardRef<
   HTMLDivElement,
   EmptyStateLinkedInNotConnectedProps
->(({ onConnect, className }, ref) => {
+>(({ onConnect, className, disabled }, ref) => {
   return (
     <EmptyState
       ref={ref}
       icon={Linkedin}
       title="LinkedIn not connected"
-      description="Connect your LinkedIn account to enable profile enrichment and Sales Navigator integration."
+      description={disabled
+        ? "Another session is in progress. Please wait for it to complete."
+        : "Connect your LinkedIn account to enable profile enrichment and Sales Navigator integration."}
       action={
         onConnect && (
           <button
             onClick={onConnect}
-            className="inline-flex items-center justify-center rounded-md px-4 py-2 text-sm font-medium bg-[#0A66C2] text-white hover:bg-[#004182] transition-colors"
+            disabled={disabled}
+            className={cn(
+              "inline-flex items-center justify-center rounded-md px-4 py-2 text-sm font-medium transition-colors",
+              disabled
+                ? "bg-gray-500 text-gray-300 cursor-not-allowed opacity-60"
+                : "bg-[#0A66C2] text-white hover:bg-[#004182]"
+            )}
           >
             <Linkedin className="mr-2 h-4 w-4" />
-            Connect LinkedIn
+            {disabled ? 'Session Busy' : 'Connect LinkedIn'}
           </button>
         )
       }

--- a/lib/docs-navigation.ts
+++ b/lib/docs-navigation.ts
@@ -1,0 +1,51 @@
+// Shared docs navigation config for sidebar, breadcrumbs, and prev/next navigation
+export interface DocsPage {
+  title: string;
+  href: string;
+  category?: string;
+}
+
+// Flat list of all docs pages in order
+export const docsPages: DocsPage[] = [
+  { title: "Getting Started", href: "/docs/getting-started", category: "Getting Started" },
+  { title: "Authentication", href: "/docs/concepts/authentication", category: "Concepts" },
+  { title: "Canonical Fields", href: "/docs/concepts/canonical-fields", category: "Concepts" },
+  { title: "Confidence Scores", href: "/docs/concepts/confidence-scores", category: "Concepts" },
+  { title: "Data Sources", href: "/docs/concepts/data-sources", category: "Concepts" },
+  { title: "Enrichment", href: "/docs/concepts/enrichment", category: "Concepts" },
+  { title: "Field Mapping", href: "/docs/concepts/field-mapping", category: "Concepts" },
+  { title: "HubSpot Integration", href: "/docs/guides/hubspot", category: "Integration Guides" },
+  { title: "LinkedIn Connection", href: "/docs/guides/linkedin", category: "Integration Guides" },
+  { title: "Enrichment Configuration", href: "/docs/advanced/enrichment-config", category: "Advanced" },
+];
+
+// Get prev/next pages for navigation
+export function getPageNavigation(currentPath: string): { prev: DocsPage | null; next: DocsPage | null } {
+  const currentIndex = docsPages.findIndex(page => page.href === currentPath);
+
+  if (currentIndex === -1) {
+    return { prev: null, next: null };
+  }
+
+  return {
+    prev: currentIndex > 0 ? docsPages[currentIndex - 1] : null,
+    next: currentIndex < docsPages.length - 1 ? docsPages[currentIndex + 1] : null,
+  };
+}
+
+// Get breadcrumb path for a docs page
+export function getBreadcrumbs(currentPath: string): { title: string; href: string }[] {
+  const breadcrumbs: { title: string; href: string }[] = [
+    { title: "Documentation", href: "/docs" },
+  ];
+
+  const page = docsPages.find(p => p.href === currentPath);
+  if (page) {
+    if (page.category) {
+      breadcrumbs.push({ title: page.category, href: "" }); // No link for category
+    }
+    breadcrumbs.push({ title: page.title, href: page.href });
+  }
+
+  return breadcrumbs;
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,9 +2,10 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   // Allow Cloudflare tunnel origins for dev server
+  // Format: hostname only, protocol is inferred
   allowedDevOrigins: [
-    "https://dev.abm.dev",
-    "https://api-dev.abm.dev",
+    "dev.abm.dev",
+    "api-dev.abm.dev",
   ],
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "react-icons": "^5.5.0",
+        "sonner": "^2.0.7",
         "tailwind-merge": "^3.4.0"
       },
       "devDependencies": {
@@ -854,6 +855,66 @@
         "fast-glob": "3.3.1"
       }
     },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "16.1.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.1.1.tgz",
+      "integrity": "sha512-JS3m42ifsVSJjSTzh27nW+Igfha3NdBOFScr9C80hHGrWx55pTrVL23RJbqir7k7/15SKlrLHhh/MQzqBBYrQA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "16.1.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.1.1.tgz",
+      "integrity": "sha512-hbyKtrDGUkgkyQi1m1IyD3q4I/3m9ngr+V93z4oKHrPcmxwNL5iMWORvLSGAf2YujL+6HxgVvZuCYZfLfb4bGw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "16.1.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.1.1.tgz",
+      "integrity": "sha512-/fvHet+EYckFvRLQ0jPHJCUI5/B56+2DpI1xDSvi80r/3Ez+Eaa2Yq4tJcRTaB1kqj/HrYKn8Yplm9bNoMJpwQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "16.1.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.1.1.tgz",
+      "integrity": "sha512-MFHrgL4TXNQbBPzkKKur4Fb5ICEJa87HM7fczFs2+HWblM7mMLdco3dvyTI+QmLBU9xgns/EeeINSZD6Ar+oLg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@next/swc-linux-x64-gnu": {
       "version": "16.1.1",
       "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.1.1.tgz",
@@ -881,6 +942,36 @@
       "optional": true,
       "os": [
         "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "16.1.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.1.1.tgz",
+      "integrity": "sha512-bdfQkggaLgnmYrFkSQfsHfOhk/mCYmjnrbRCGgkMcoOBZ4n+TRRSLmT/CU5SATzlBJ9TpioUyBW/vWFXTqQRiA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "16.1.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.1.1.tgz",
+      "integrity": "sha512-Ncwbw2WJ57Al5OX0k4chM68DKhEPlrXBaSXDCi2kPi5f4d8b3ejr3RRJGfKBLrn2YJL5ezNS7w2TZLHSti8CMw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">= 10"
@@ -8880,6 +8971,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/sonner": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
+      "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/source-map": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "react-icons": "^5.5.0",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.4.0"
   },
   "devDependencies": {

--- a/public/api-docs.html
+++ b/public/api-docs.html
@@ -52,8 +52,30 @@
     .sl-inverted,
     [class*="Panel"],
     nav,
-    aside {
+    aside,
+    main,
+    article,
+    section,
+    div[class*="Article"],
+    div[class*="Content"],
+    div[class*="Page"],
+    div[class*="Docs"],
+    div[class*="StackedLayout"],
+    div[class*="TwoColumn"],
+    .sl-overflow-y-auto,
+    .sl-flex,
+    .sl-bg-canvas {
       background: #0A1F3D !important;
+      background-color: #0A1F3D !important;
+    }
+
+    /* Force canvas background colors */
+    .sl-bg-canvas-100,
+    .sl-bg-canvas-50,
+    .sl-bg-canvas-pure,
+    [class*="bg-canvas"] {
+      background: #0A1F3D !important;
+      background-color: #0A1F3D !important;
     }
 
     .sl-elements h1,
@@ -92,9 +114,36 @@
       color: #40E0D0 !important;
     }
 
+    /* Tables and rows */
+    .sl-elements table,
+    .sl-elements tr,
+    .sl-elements td,
+    .sl-elements th,
+    .sl-elements tbody,
+    .sl-elements thead,
+    [class*="Table"],
+    [class*="Row"] {
+      background: transparent !important;
+      background-color: transparent !important;
+    }
+
+    /* Request/Response panels */
+    [class*="HttpOperation"],
+    [class*="Request"],
+    [class*="Response"],
+    [class*="TryIt"],
+    [class*="Viewer"] {
+      background: #0d2a4d !important;
+      border-color: rgba(64, 224, 208, 0.2) !important;
+    }
+
     /* Code blocks */
     .sl-elements pre,
-    .sl-elements code {
+    .sl-elements code,
+    [class*="CodeViewer"],
+    [class*="JsonSchema"],
+    .sl-code-viewer,
+    [class*="code"] {
       background: rgba(26, 26, 46, 0.8) !important;
       border-color: rgba(64, 224, 208, 0.2) !important;
       color: #FAEBD7 !important;


### PR DESCRIPTION
## Summary

Complete portal overhaul covering 10 sprints of improvements:

- **Sprint 1**: Browserbase session management - cleanup, availability handling, exponential backoff
- **Sprint 2-3**: Custom API Reference - new sidebar, endpoint cards, and documentation for all endpoints
- **Sprint 4**: Toast notifications - replaced all alert/confirm with sonner toasts and modals
- **Sprint 5**: Settings polish - reorganized hub, delete account modal
- **Sprint 6**: Dashboard improvements - stats cards, usage bars, activity feed, integration status
- **Sprint 7**: Loading states - skeleton screens for all pages
- **Sprint 8**: Mobile & accessibility - skip-to-content, proper ARIA landmarks
- **Sprint 9**: Documentation - breadcrumbs, prev/next navigation
- **Sprint 10**: Production readiness - 404/error pages, SEO metadata, debug cleanup

## Changes

### New Components
- `ApiSidebar`, `EndpointCard`, `MethodBadge`, `ParameterTable`, `ResponseExample`
- `StatsCard`, `UsageBar`, `ActivityFeed`, `IntegrationStatus`
- `Breadcrumbs`, `PageNavigation`, `SkipToContent`
- `DeleteAccountModal`, `DeleteAccountButton`

### New Pages
- `/api-reference/enrichment`, `/jobs`, `/integrations`, `/linkedin`, `/configuration`
- `/not-found` (custom 404)
- `/error` (error boundary)

### Improvements
- Loading skeletons for dashboard, settings, api-keys, api-reference
- Toast notifications via sonner
- Enhanced SEO metadata with OpenGraph tags
- Accessibility: skip links, main-content IDs

## Test plan

- [ ] Verify all API Reference pages render correctly
- [ ] Test toast notifications on settings pages
- [ ] Check loading skeletons appear during page transitions
- [ ] Test 404 page by visiting invalid URL
- [ ] Verify skip-to-content link works with keyboard navigation
- [ ] Test prev/next navigation on docs pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)